### PR TITLE
FED-890 (feat) add method to allow auto-consent on CMP

### DIFF
--- a/config/common.webpack.config.babel.js
+++ b/config/common.webpack.config.babel.js
@@ -157,6 +157,19 @@ const commonConfig = {
 		__filename: false,
 		__dirname: false,
 		setImmediate: false
+	},
+	devtool: ENV === 'production' ? 'source-map' : 'cheap-module-eval-source-map',
+
+	devServer: {
+		port: process.env.PORT || 8080,
+		host: 'localhost',
+		publicPath: '/',
+		contentBase: './src',
+		historyApiFallback: true,
+		disableHostCheck: true,
+		open: false,
+		openPage: 'docs/',
+		https: false
 	}
 };
 

--- a/config/webpack.config.babel.js
+++ b/config/webpack.config.babel.js
@@ -39,7 +39,10 @@ module.exports = [
 				filename: 'index.html',
 				template: 'index.html',
 				chunks: ['cmp']
-			})
+			}),
+			new CopyWebpackPlugin([
+				{ from: '../serve.json', to: '.' }
+			]),
 		].concat(ENV === 'production' ? uglifyPlugin : [])
 	},
 	// Docs config

--- a/src/components/app.jsx
+++ b/src/components/app.jsx
@@ -36,7 +36,6 @@ export default class App extends Component {
 			store,
 		} = state;
 		const {
-			shouldAutoAccept,
 			theme,
 		} = props;
 
@@ -51,7 +50,6 @@ export default class App extends Component {
 				<Banner isShowing={isBannerShowing}
 						isModalShowing={isModalShowing}
 						onSave={this.onSave}
-						shouldAutoAccept={shouldAutoAccept}
 						onShowModal={toggleModalShowing}
 						theme={theme}
 				/>

--- a/src/components/app.jsx
+++ b/src/components/app.jsx
@@ -36,6 +36,7 @@ export default class App extends Component {
 			store,
 		} = state;
 		const {
+			shouldAutoAccept,
 			theme,
 		} = props;
 
@@ -50,6 +51,7 @@ export default class App extends Component {
 				<Banner isShowing={isBannerShowing}
 						isModalShowing={isModalShowing}
 						onSave={this.onSave}
+						shouldAutoAccept={shouldAutoAccept}
 						onShowModal={toggleModalShowing}
 						theme={theme}
 				/>

--- a/src/components/banner/banner.jsx
+++ b/src/components/banner/banner.jsx
@@ -12,7 +12,6 @@ class LocalLabel extends Label {
 const PANEL_COLLECTED = 0;
 const PANEL_PURPOSE = 1;
 
-
 export default class Banner extends Component {
 
 	constructor(props) {
@@ -21,6 +20,33 @@ export default class Banner extends Component {
 			isExpanded: false,
 			selectedPanelIndex: 0,
 		};
+	}
+	componentDidUpdate = (prevProps) => {
+		const {isShowing} = this.props;
+		const {isShowing: isShowingPrev} = prevProps;
+		if (isShowing !== isShowingPrev) {
+			this.toggleKeyDownEvent(isShowing);
+		}
+	}
+
+	componentWillUnmount = () => {
+		this.toggleKeyDownEvent(false);
+	}
+
+	toggleKeyDownEvent = (isShowing) => {
+		document.onkeydown = null; // remove event
+		if (isShowing) {
+			document.onkeydown = this.onKeyDown; // add event listener
+		}
+	}
+
+	onKeyDown = (evt) => {
+		evt = evt || window.event;
+		const {key = '', keyCode = ''} = evt;
+		const isEscape = (key === 'Escape' || key === 'Esc' || keyCode === 27);
+		if (isEscape) {
+			this.props.onSave();
+		}
 	}
 
 	handleInfo = (index) => () => {

--- a/src/lib/cmp.js
+++ b/src/lib/cmp.js
@@ -177,6 +177,13 @@ export default class Cmp {
 		showModal: (_, callback = () => {}) => {
 			this.store.toggleModalShowing(true);
 			callback(true);
+		},
+
+		/**
+		 * Trigger the consent tool to consent to all criteria
+		 */
+		consentAll: () => {
+			this.store.persist();
 		}
 	};
 

--- a/src/lib/cmp.js
+++ b/src/lib/cmp.js
@@ -182,8 +182,9 @@ export default class Cmp {
 		/**
 		 * Trigger the consent tool to consent to all criteria
 		 */
-		consentAll: () => {
+		acceptAllConsents: (_, callback = () => {}) => {
 			this.store.persist();
+			callback();
 		}
 	};
 

--- a/src/lib/cmp.test.js
+++ b/src/lib/cmp.test.js
@@ -148,6 +148,14 @@ describe('cmp', () => {
 			});
 		});
 
+		it('acceptAllConsents executes', (done) => {
+			const persist = jest.spyOn(cmp.store, 'persist');
+			cmp.processCommand('acceptAllConsents', null, () => {
+				expect(persist.mock.calls).to.have.length(1);
+				done();
+			});
+		});
+
 		describe('addEventListener', () => {
 
 			it('only adds the callback instance once', () => {
@@ -222,5 +230,4 @@ describe('cmp', () => {
 
 		expect(processSpy.mock.calls[0][0]).to.equal('showConsentTool');
 	});
-
 });

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -8,6 +8,7 @@ const defaultConfig = {
 	storeConsentGlobally: false,
 	storePublisherData: false,
 	logging: false,
+	testing: false,
 	localization: {},
 	forceLocale: null,
 	gdprApplies: true,

--- a/src/lib/init.js
+++ b/src/lib/init.js
@@ -59,7 +59,10 @@ export function init(configUpdates) {
 				...cmp.commands,
 				notify: cmp.notify,
 				isLoaded: cmp.isLoaded,
-				processCommand: cmp.processCommand
+				processCommand: cmp.processCommand,
+				acceptAll: () => {
+					store.persist();
+				}
 			});
 
 			cmp.notify('isLoaded');

--- a/src/lib/init.js
+++ b/src/lib/init.js
@@ -59,10 +59,7 @@ export function init(configUpdates) {
 				...cmp.commands,
 				notify: cmp.notify,
 				isLoaded: cmp.isLoaded,
-				processCommand: cmp.processCommand,
-				acceptAll: () => {
-					store.persist();
-				}
+				processCommand: cmp.processCommand
 			});
 
 			cmp.notify('isLoaded');

--- a/src/lib/init.js
+++ b/src/lib/init.js
@@ -62,6 +62,12 @@ export function init(configUpdates) {
 				processCommand: cmp.processCommand
 			});
 
+			if (config.testing) {
+				Object.assign(window[CMP_GLOBAL_NAME], {
+					cmp
+				});
+			}
+
 			cmp.notify('isLoaded');
 
 			// Render the UI

--- a/src/s1/cmp.js
+++ b/src/s1/cmp.js
@@ -78,7 +78,7 @@ const handleConsentResult = ({
 		if (shouldAutoConsent) {
 			return (() => {
 				log.debug("CMP: auto-consent to all conditions.");
-				cmp.acceptAll();
+				cmp('acceptAllConsents');
 				checkConsent(callback);
 			})();
 		}

--- a/src/s1/reference.hbs
+++ b/src/s1/reference.hbs
@@ -57,7 +57,7 @@
 		const config = {
 			scriptSrc: window.location.search.indexOf("remote=true") >= 0 ? 'https://s.flocdn.com/cmp/{{{htmlWebpackPlugin.options.version}}}/cmp.js' : './cmp.js',
 			// scriptSrc: './s1.cmp.js',
-			// logging: false,
+			logging: false,
 			// pubVendorListLocation: './pubvendors.json',
 			// pubVendorListLocation: 'https://s.flocdn.com/cmp/pubvendors.json',
 			// logging: false,
@@ -69,6 +69,7 @@
 			// localization: {},
 			// forceLocale: null,
 			gdprApplies: true,
+			shouldAutoConsent: true,
 			// allowedVendorIds: null
 		}
 
@@ -85,6 +86,7 @@
 		cmp('init', config, function (result) {
 			if (result.consentRequired) {
 				if (result.errorMsg) {
+					console.log('init', 'showConsentTool', result);
 					cmp('showConsentTool');
 					cmp('addEventListener', 'onConsentChanged', onConsentChanged);
 				} else {

--- a/src/s1/reference.hbs
+++ b/src/s1/reference.hbs
@@ -58,6 +58,7 @@
 			scriptSrc: window.location.search.indexOf("remote=true") >= 0 ? 'https://s.flocdn.com/cmp/{{{htmlWebpackPlugin.options.version}}}/cmp.js' : './cmp.js',
 			// scriptSrc: './s1.cmp.js',
 			logging: false,
+			testing: true,
 			// pubVendorListLocation: './pubvendors.json',
 			// pubVendorListLocation: 'https://s.flocdn.com/cmp/pubvendors.json',
 			// logging: false,
@@ -69,7 +70,7 @@
 			// localization: {},
 			// forceLocale: null,
 			gdprApplies: true,
-			shouldAutoConsent: true,
+			shouldAutoConsent: false,
 			// allowedVendorIds: null
 		}
 

--- a/src/s1/test/loader.import.test.js
+++ b/src/s1/test/loader.import.test.js
@@ -70,4 +70,76 @@ describe('cmpLoader as import', () => {
 			);
 		});
 	});
+
+	it('auto accepts consents', done => {
+		global.cmp(
+			'init',
+			{
+				scriptSrc: fakeScriptSrc,
+				gdprApplies: true,
+				shouldAutoConsent: true
+			},
+			(result) => {
+				expect(result.consentRequired).to.be.true;
+				expect(result.errorMsg).to.be.empty;
+				expect(document.cookie.indexOf("gdpr_opt_in=1")).to.be.above(1);
+				done();
+			}
+		);
+	});
+
+
+	it('exposes cmp when testing config present', done => {
+		global.cmp(
+			'init',
+			{
+				scriptSrc: fakeScriptSrc,
+				gdprApplies: true,
+				testing: true
+			},
+			() => {
+				expect(global.cmp.cmp).to.exist;
+				expect(global.cmp.cmp.store).to.exist;
+				done();
+			}
+		);
+	});
+
+	it('updates gdpr_opt_in when consent changes', done => {
+		global.cmp(
+			'init',
+			{
+				scriptSrc: fakeScriptSrc,
+				gdprApplies: true,
+				shouldAutoConsent: true,
+				testing: true
+			},
+			(result) => {
+				expect(result.consentRequired).to.be.true;
+				expect(result.errorMsg).to.be.empty;
+				expect(document.cookie.indexOf("gdpr_opt_in=1")).to.be.above(1);
+
+				const {cmp: {cmp : cmpStub}} = global;
+
+				cmpStub.store.selectVendor(1, false);
+				console.log(0, result);
+				global.cmp('getVendorConsents', null, data => {
+					console.log(1, data);
+					expect(data.vendorConsents['1']).to.be.true;
+					console.log(2);
+					cmpStub.store.persist();
+					console.log(3);
+					global.cmp('getVendorConsents', null, data2 => {
+						console.log(4, data2);
+						expect(data2.vendorConsents['1']).to.be.false;
+						console.log(5);
+						console.log("gdpr_opt_in", document.cookie);
+						expect(document.cookie.indexOf("gdpr_opt_in=0")).to.be.above(1);
+						console.log(6);
+						done();
+					});
+				});
+			}
+		);
+	});
 });

--- a/src/s1/test/loader.inline.test.js
+++ b/src/s1/test/loader.inline.test.js
@@ -169,5 +169,73 @@ describe('cmpLoader as script tag', () => {
 
 			global.cmp('addEventListener', 'isLoaded', callback);
 		});
+
+		// it('auto accepts consents', done => {
+		// 	global.cmp(
+		// 		'init',
+		// 		{
+		// 			scriptSrc: fakeScriptSrc,
+		// 			gdprApplies: true,
+		// 			shouldAutoConsent: true
+		// 		},
+		// 		(result) => {
+		// 			expect(result.consentRequired).to.be.true;
+		// 			expect(result.errorMsg).to.be.empty;
+		// 			expect(document.cookie.indexOf("gdpr_opt_in=1")).to.be.above(1);
+		// 			done();
+		// 		}
+		// 	);
+		// });
+
+
+		it('exposes cmp when testing config present', done => {
+			global.cmp(
+				'init',
+				{
+					scriptSrc: fakeScriptSrc,
+					gdprApplies: true,
+					testing: true
+				},
+				() => {
+					expect(global.cmp.cmp).to.exist;
+					expect(global.cmp.cmp.store).to.exist;
+					done();
+				}
+			);
+		});
+
+		/*
+		it('updates gdpr_opt_in when consent changes', done => {
+			global.cmp(
+				'init',
+				{
+					scriptSrc: fakeScriptSrc,
+					gdprApplies: true,
+					shouldAutoConsent: true,
+					testing: true
+				},
+				(result) => {
+					expect(result.consentRequired).to.be.true;
+					expect(result.errorMsg).to.be.empty;
+					expect(document.cookie.indexOf("gdpr_opt_in=1")).to.be.above(1);
+					console.log("cookie", document.cookie);
+
+					const {cmp: {cmp : cmpStub}} = global;
+
+					cmpStub.store.selectVendor(1, false);
+					global.cmp('getVendorConsents', null, data => {
+						expect(data.vendorConsents['1']).to.be.true;
+						cmpStub.store.persist();
+						global.cmp('getVendorConsents', null, data => {
+							expect(data.vendorConsents['1']).to.be.false;
+							expect(document.cookie.indexOf("gdpr_opt_in=0")).to.be.above(1);
+							done();
+						});
+					});
+				}
+			);
+		});
+		*/
+
 	});
 });


### PR DESCRIPTION
## Background

Ticket: https://github.com/Openmail/OpenMail/pull/20787 
 - [x] Fix dev mode issue so `yarn dev:s1` works again
 - [ ] Enable click-window to consent
 - [ ] Enable escape-key to consent
 - [ ] Expose a method to consent programmatically 

## Test Plan

Auto
```
yarn test
```
Manual
```
yarn dev:s1
# http://localhost:8080/reference.html / clear cookies 
# see that euconsent is set with all purposes selected when you load the page 
```