### PR TITLE
FED-1156 feat (cmp) add locator iframe and postmessage support with …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Feat
 
  - [x] support `storeConsentGlobally` feature by adding postmessage/iframe solution
+   - With `storeConsentGlobally` true; the euconsent cookie is set on the `globalConsentLocation` domain. 
+   - In the reference example, the cookie is set at `s.flocdn.com` 
 
 <a name="0.0.4-modal"></a>
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+<a name="0.0.5-modal"></a>
+
+## [0.0.5-modal](https://github.com/Openmail/system1-cmp/compare/v0.0.4-modal...v0.0.5-modal) (2019-07-18)
+
+### Feat
+
+ - [x] support `storeConsentGlobally` feature by adding postmessage/iframe solution
+
 <a name="0.0.4-modal"></a>
 
 ## [0.0.4-modal](https://github.com/Openmail/system1-cmp/compare/v0.0.3-modal...v0.0.4-modal) (2019-07-10)

--- a/CMP-LOADER.md
+++ b/CMP-LOADER.md
@@ -246,3 +246,12 @@ cmp('addEventListener', 'onSubmit', (event) => console.log(event));
 ```
 yarn deploy
 ```
+
+# Local Development
+
+You can start a development server that will monitor changes to all CMP and docs files with:
+```sh
+yarn dev:s1
+```
+
+Access the System1 s1cmp complete reference at http://localhost:8080/reference.html

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "appnexus-cmp",
-	"version": "0.0.4-modal",
+	"version": "0.0.5-modal",
 	"scripts": {
 		"clean": "rimraf ./dist",
 		"dev": "cross-env NODE_ENV=development webpack-dev-server --inline --hot --progress --config config/webpack.config.babel.js",

--- a/src/components/popup/popup.less
+++ b/src/components/popup/popup.less
@@ -31,7 +31,6 @@
 	position: relative;
 
 	@media @smartphone {
-		width: 90%;
 		height: 90%;
 	}
 }

--- a/src/components/popup/popup.less
+++ b/src/components/popup/popup.less
@@ -24,6 +24,7 @@
 	width: 700px;
 	max-width: 90%;
 	height: 500px;
+	max-height: 100%;
 	background: white;
 	display: flex;
 	align-items: center;

--- a/src/s1/cmp.js
+++ b/src/s1/cmp.js
@@ -48,6 +48,10 @@ const addPostmessageReceiver = (cmp) => {
 };
 
 const initialize = (config, callback) => {
+	// storeConsentGlobally will fail to store cookie if third party cookies are disabled
+	// TODO: check to see if 3rdpartycookies are enabled and force the user into storeConsentLocally if so
+	// https://github.com/mindmup/3rdpartycookiecheck
+
 	init(config, cmp).then(() => {
 		addPostmessageReceiver(cmp);
 		addLocatorFrame();

--- a/src/s1cmp.hbs
+++ b/src/s1cmp.hbs
@@ -1,15 +1,18 @@
 <!DOCTYPE html>
 <html>
+
 <head>
 	<meta charset="utf-8">
 	<title>System1 CMP</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, minimal-ui">
 </head>
+
 <body>
 	<!--// INLINE
 	<script>{{{ htmlWebpackPlugin.options.inline }}}</script>
 	-->
-
+	<h1>System1 CMP Reference Page</h1>
+	<button id="show-button">showConsentTool</button>
 	<!--// LOADER //-->
 	<script src="./loader.js"></script>
 	<script>
@@ -22,15 +25,15 @@
 			// logging: false,
 			// customPurposeListLocation: './purposes.json',
 			// globalVendorListLocation: 'https://vendorlist.consensu.org/vendorlist.json',
-			// globalConsentLocation: './portal.html',
-			// storeConsentGlobally: false,
+			globalConsentLocation: 'https://s.flocdn.com/cmp/docs/portal.html',
+			storeConsentGlobally: true,
 			// storePublisherData: false,
 			// localization: {},
 			// forceLocale: null,
 			gdprApplies: true,
 			// allowedVendorIds: null,
-			shouldAutoConsent: true,
-			shouldAutoConsentWithFooter: true
+			shouldAutoConsent: false,
+			shouldAutoConsentWithFooter: false
 		}
 
 		function onConsentChanged(result) {
@@ -62,6 +65,10 @@
 			}
 		});
 
+		const showBtn = document.getElementById('show-button');
+		showBtn.addEventListener('click', () => {
+			cmp('showConsentTool');
+		});
 	</script>
 
 
@@ -89,4 +96,5 @@
 	//-->
 
 </body>
+
 </html>


### PR DESCRIPTION
…globalConsentLocation

## background
ticket: https://openmail.atlassian.net/browse/FED-1156

- [x] support `storeConsentGlobally` by adding iframe/postMessage solution for 3rd party cookie

## test plan

- [x] make sure global consent works as expected
- [x] check global consent falls back to local consent on safari where 3rd party cookies disabled
  - result: there is not a fallback to `storeConsentLocally` if 3rd-party cookies are disabled; this appears to be by design though. If we want to patch this functionality, I've left a todo with comments