### PR TITLE
FED-1193 refactor (banner: ui) provide a direct link to the vendor li…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+<a name="1.1.1"></a>
+
+## [1.1.1](https://github.com/openmail/system1-cmp/compare/v1.1.0...v1.1.1) (2019-09-04)
+
+### Refactor
+
+ - [x] For Policy Check 3 (provide a direct link to the vendor list in first UI layer), render the `<Banner>` with the Vendor Purposes accordion expanded.
+
 <a name="1.1.0"></a>
 
 ## [1.1.0](https://github.com/openmail/system1-cmp/compare/v1.0.0...v1.1.0) (2019-09-03)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appnexus-cmp",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "scripts": {
     "clean": "rimraf ./dist",
     "dev": "cross-env NODE_ENV=development webpack-dev-server --inline --hot --progress --config config/webpack.config.babel.js",

--- a/src/components/banner/banner.jsx
+++ b/src/components/banner/banner.jsx
@@ -25,8 +25,8 @@ export default class Banner extends Component {
 	constructor(props) {
 		super(props);
 		this.state = {
-			isExpanded: false,
-			selectedPanelIndex: 0,
+			isExpanded: true,
+			selectedPanelIndex: 1,
 		};
 	}
 


### PR DESCRIPTION
## background
ticket: https://openmail.atlassian.net/browse/FED-1193

- [x] Option 1. Open the "Purposes for storing information" accordion so the user sees the following links in the First UI Layer: (each link opens modal with list of vendors for that purpose)

## test plan
```
yarn dev:s1 
```
See that the Purposes accordion is open by default

<img width="471" alt="Screen Shot 2019-09-04 at 9 11 09 AM" src="https://user-images.githubusercontent.com/468002/64272322-f556ec00-cef3-11e9-8ef5-5875dc7da6ff.png">

