### PR TITLE
SERV-1190 refactor (init: autoConsentFooter) auto consent with Banner instead of Footer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+<a name="1.3.1"></a>
+
+## [1.3.1](https://github.com/openmail/system1-cmp/compare/v1.3.0...v1.3.1) (2019-11-21)
+
+### Refactor
+
+- [x] autoconsent should open Banner instead of interstitial
+
 <a name="1.3.0"></a>
 
 ## [1.3.0](https://github.com/openmail/system1-cmp/compare/v1.2.0...v1.3.0) (2019-11-20)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "system1-cmp",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "System1 Consent Management Platform for GDPR Compliance",
   "scripts": {
     "clean": "rimraf ./dist",

--- a/src/s1/cmp.js
+++ b/src/s1/cmp.js
@@ -127,10 +127,7 @@ const handleConsentResult = ({
 	const autoConsentFlow = (shouldAutoConsentWithFooter, warningMsg = '') => {
 		cmp('acceptAllConsents');
 		if (shouldAutoConsentWithFooter) {
-			const store = getStore();
-			if (store) {
-				store.toggleFooterShowing(true);
-			}
+			cmp('showConsentTool');
 		}
 		checkConsent({
 			callback,


### PR DESCRIPTION
## background

 - [x] auto consent flow pops Banner instead of old Footer

## test plan
Auto
```
yarn test
```
Manual
```
yarn dev
# turn on shouldAutoConsentWithFooter in reference page
# browse to http://localhost:8080/reference.html 
```
<img width="1530" alt="Screen Shot 2019-11-21 at 3 27 03 PM" src="https://user-images.githubusercontent.com/468002/69385238-8c218200-0c73-11ea-9d16-acf4c28c3e3f.png">
