### PR TITLE
NS-1963 fix (cmp: cookie) coerce cookie to boolean and update order of callback and consent-change trigger

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,1 @@
-src/s1/loader.js
+**/loader.js

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,10 +1,7 @@
 {
   "parser": "babel-eslint",
   "extends": "eslint:recommended",
-  "plugins": [
-    "react",
-    "jest"
-  ],
+  "plugins": ["react", "jest"],
   "env": {
     "browser": true,
     "node": true,
@@ -52,7 +49,7 @@
     "camelcase": 0,
     "comma-style": 2,
     "comma-dangle": 0,
-    "indent": [2, "tab", {"SwitchCase": 1}],
+    "indent": [2, "tab", { "SwitchCase": 1 }],
     "no-mixed-spaces-and-tabs": [2, "smart-tabs"],
     "no-trailing-spaces": [2, { "skipBlankLines": true }],
     "max-nested-callbacks": [2, 3],
@@ -81,6 +78,7 @@
     "no-useless-concat": 2,
     "no-var": 2,
     "object-shorthand": 2,
-    "prefer-arrow-callback": 2
+    "prefer-arrow-callback": 2,
+    "quotes": [1, "single"]
   }
 }

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+**/loader.js

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "singleQuote": true,
+  "bracketSpacing": true,
+  "printWidth": 120
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,0 @@
-{
-    "prettier.singleQuote": true,
-    "prettier.bracketSpacing": false
-}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fix
 
 - [x] Coerce cookie to Boolean to fix '0' coercing to True in onConsentChanged
+- [x] Fix failing autoConsent footer test to test Banner
 
 <a name="1.3.1"></a>
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+<a name="1.3.2"></a>
+
+## [1.3.2](https://github.com/openmail/system1-cmp/compare/v1.3.1...v1.3.2) (2019-11-22)
+
+### Refactor
+
+- [x] Trigger onConsentChanged after callback in init to avoid double calls
+
+### Fix
+
+- [x] Coerce cookie to Boolean to fix '0' coercing to True in onConsentChanged
+
 <a name="1.3.1"></a>
 
 ## [1.3.1](https://github.com/openmail/system1-cmp/compare/v1.3.0...v1.3.1) (2019-11-21)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Refactor
 
 - [x] Trigger onConsentChanged after callback in init to avoid double calls
+- [x] eslint / prettier configs and run updates to fix formatting incongruities
 
 ### Fix
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "system1-cmp",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "System1 Consent Management Platform for GDPR Compliance",
   "scripts": {
     "clean": "rimraf ./dist",

--- a/src/docs/assets/portal.js
+++ b/src/docs/assets/portal.js
@@ -1,6 +1,6 @@
 import Promise from 'promise-polyfill';
 import 'whatwg-fetch';
-import log from "../../lib/log";
+import log from '../../lib/log';
 
 const host = (window && window.location && window.location.hostname) || '';
 const parts = host.split('.');
@@ -16,7 +16,7 @@ const readVendorListPromise = fetch('./vendorlist.json', {
 })
 	.then(res => res.json())
 	.catch(err => {
-		log.error(`Failed to load vendor list from vendors.json`, err);
+		log.error('Failed to load vendor list from vendors.json', err);
 	});
 
 function readCookie(name) {

--- a/src/lib/cmp.js
+++ b/src/lib/cmp.js
@@ -1,10 +1,7 @@
 import log from './log';
 import config from './config';
 import { encodeVendorConsentData } from './cookie/cookie';
-import {
-	encodeVendorCookieValue,
-	encodePublisherCookieValue
-} from "./cookie/cookieutils";
+import { encodeVendorCookieValue, encodePublisherCookieValue } from './cookie/cookieutils';
 
 export const CMP_GLOBAL_NAME = '__cmp';
 export const CMP_CALL_NAME = CMP_GLOBAL_NAME + 'Call';
@@ -28,26 +25,26 @@ export default class Cmp {
 		 * Get all publisher consent data from the data store.
 		 */
 		getPublisherConsents: (purposeIds, callback = () => {}) => {
-			const {
-				persistedPublisherConsentData,
-				persistedVendorConsentData,
-			} = this.store;
+			const { persistedPublisherConsentData, persistedVendorConsentData } = this.store;
 
 			// Encode limited fields for "metadata"
-			const metadata = encodePublisherCookieValue({
-				...persistedPublisherConsentData,
-				...persistedVendorConsentData,
-			}, [
-				'cookieVersion',
-				'created',
-				'lastUpdated',
-				'cmpId',
-				'cmpVersion',
-				'consentScreen',
-				'consentLanguage',
-				'vendorListVersion',
-				'publisherPurposeVersion'
-			]);
+			const metadata = encodePublisherCookieValue(
+				{
+					...persistedPublisherConsentData,
+					...persistedVendorConsentData
+				},
+				[
+					'cookieVersion',
+					'created',
+					'lastUpdated',
+					'cmpId',
+					'cmpVersion',
+					'consentScreen',
+					'consentLanguage',
+					'vendorListVersion',
+					'publisherPurposeVersion'
+				]
+			);
 
 			const consent = {
 				metadata,
@@ -63,19 +60,20 @@ export default class Cmp {
 		 * @param {Array} vendorIds Array of vendor IDs to retrieve.  If empty return all vendors.
 		 */
 		getVendorConsents: (vendorIds, callback = () => {}) => {
-
 			// Encode limited fields for "metadata"
 			const { persistedVendorConsentData } = this.store;
-			const metadata = persistedVendorConsentData && encodeVendorCookieValue(persistedVendorConsentData, [
-				'cookieVersion',
-				'created',
-				'lastUpdated',
-				'cmpId',
-				'cmpVersion',
-				'consentScreen',
-				'consentLanguage',
-				'vendorListVersion',
-			]);
+			const metadata =
+				persistedVendorConsentData &&
+				encodeVendorCookieValue(persistedVendorConsentData, [
+					'cookieVersion',
+					'created',
+					'lastUpdated',
+					'cmpId',
+					'cmpVersion',
+					'consentScreen',
+					'consentLanguage',
+					'vendorListVersion'
+				]);
 
 			const consent = {
 				metadata,
@@ -107,8 +105,7 @@ export default class Cmp {
 			const { vendorListVersion: listVersion } = vendorList || {};
 			if (!vendorListVersion || vendorListVersion === listVersion) {
 				callback(vendorList, true);
-			}
-			else {
+			} else {
 				callback(null, false);
 			}
 		},
@@ -178,34 +175,30 @@ export default class Cmp {
 			this.store.toggleModalShowing(true);
 			callback(true);
 		},
-		
+
 		acceptAllConsents: (_, callback = () => {}) => {
 			this.store.persist();
 			callback();
 		}
-
-		
 	};
 
 	generateConsentString = () => {
-		const {
-			persistedVendorConsentData,
-			vendorList,
-			allowedVendorIds
-		} = this.store;
+		const { persistedVendorConsentData, vendorList, allowedVendorIds } = this.store;
 
-		const {
-			selectedVendorIds = new Set(),
-			selectedPurposeIds = new Set()
-		} = persistedVendorConsentData || {};
+		const { selectedVendorIds = new Set(), selectedPurposeIds = new Set() } = persistedVendorConsentData || {};
 
 		// Encode the persisted data
-		return persistedVendorConsentData && encodeVendorConsentData({
-			...persistedVendorConsentData,
-			selectedVendorIds: new Set(Array.from(selectedVendorIds).filter(id => !allowedVendorIds.size || allowedVendorIds.has(id))),
-			selectedPurposeIds: new Set(Array.from(selectedPurposeIds)),
-			vendorList
-		});
+		return (
+			persistedVendorConsentData &&
+			encodeVendorConsentData({
+				...persistedVendorConsentData,
+				selectedVendorIds: new Set(
+					Array.from(selectedVendorIds).filter(id => !allowedVendorIds.size || allowedVendorIds.has(id))
+				),
+				selectedPurposeIds: new Set(Array.from(selectedPurposeIds)),
+				vendorList
+			})
+		);
 	};
 
 	processCommandQueue = () => {
@@ -217,15 +210,18 @@ export default class Cmp {
 				// If command is queued with an event we will relay its result via postMessage
 				if (event) {
 					this.processCommand(command, parameter, returnValue =>
-						event.source.postMessage({
-							[CMP_RETURN_NAME]: {
-								callId,
-								command,
-								returnValue
-							}
-						}, event.origin));
-				}
-				else {
+						event.source.postMessage(
+							{
+								[CMP_RETURN_NAME]: {
+									callId,
+									command,
+									returnValue
+								}
+							},
+							event.origin
+						)
+					);
+				} else {
 					this.processCommand(command, parameter, callback);
 				}
 			});
@@ -241,13 +237,17 @@ export default class Cmp {
 		if (cmp) {
 			const { callId, command, parameter } = cmp;
 			this.processCommand(command, parameter, returnValue =>
-				source.postMessage({
-					[CMP_RETURN_NAME]: {
-						callId,
-						command,
-						returnValue
-					}
-				}, origin));
+				source.postMessage(
+					{
+						[CMP_RETURN_NAME]: {
+							callId,
+							command,
+							returnValue
+						}
+					},
+					origin
+				)
+			);
 		}
 	};
 

--- a/src/lib/cmp.test.js
+++ b/src/lib/cmp.test.js
@@ -11,49 +11,49 @@ jest.mock('./log');
 const mockLog = require('./log').default;
 
 const vendorList = {
-	"version": 1,
-	"purposes": [
+	'version': 1,
+	'purposes': [
 		{
-			"id": 1,
-			"name": "Accessing a Device or Browser"
+			'id': 1,
+			'name': 'Accessing a Device or Browser'
 		},
 		{
-			"id": 2,
-			"name": "Advertising Personalisation"
+			'id': 2,
+			'name': 'Advertising Personalisation'
 		},
 		{
-			"id": 3,
-			"name": "Analytics"
+			'id': 3,
+			'name': 'Analytics'
 		},
 		{
-			"id": 4,
-			"name": "Content Personalisation"
+			'id': 4,
+			'name': 'Content Personalisation'
 		}
 	],
-	"vendors": [
+	'vendors': [
 		{
-			"id": 1,
-			"name": "Globex"
+			'id': 1,
+			'name': 'Globex'
 		},
 		{
-			"id": 2,
-			"name": "Initech"
+			'id': 2,
+			'name': 'Initech'
 		},
 		{
-			"id": 3,
-			"name": "CRS"
+			'id': 3,
+			'name': 'CRS'
 		},
 		{
-			"id": 4,
-			"name": "Umbrella"
+			'id': 4,
+			'name': 'Umbrella'
 		},
 		{
-			"id": 5,
-			"name": "Aperture"
+			'id': 5,
+			'name': 'Aperture'
 		},
 		{
-			"id": 6,
-			"name": "Pierce and Pierce"
+			'id': 6,
+			'name': 'Pierce and Pierce'
 		}
 	]
 };

--- a/src/lib/cookie/cookie.test.js
+++ b/src/lib/cookie/cookie.test.js
@@ -22,50 +22,50 @@ jest.mock('../portal');
 const mockPortal = require('../portal');
 
 const vendorList = {
-	"version": 1,
-	"origin": "http://ib.adnxs.com/vendors.json",
-	"purposes": [
+	'version': 1,
+	'origin': 'http://ib.adnxs.com/vendors.json',
+	'purposes': [
 		{
-			"id": 1,
-			"name": "Accessing a Device or Browser"
+			'id': 1,
+			'name': 'Accessing a Device or Browser'
 		},
 		{
-			"id": 2,
-			"name": "Advertising Personalisation"
+			'id': 2,
+			'name': 'Advertising Personalisation'
 		},
 		{
-			"id": 3,
-			"name": "Analytics"
+			'id': 3,
+			'name': 'Analytics'
 		},
 		{
-			"id": 4,
-			"name": "Content Personalisation"
+			'id': 4,
+			'name': 'Content Personalisation'
 		}
 	],
-	"vendors": [
+	'vendors': [
 		{
-			"id": 1,
-			"name": "Globex"
+			'id': 1,
+			'name': 'Globex'
 		},
 		{
-			"id": 2,
-			"name": "Initech"
+			'id': 2,
+			'name': 'Initech'
 		},
 		{
-			"id": 3,
-			"name": "CRS"
+			'id': 3,
+			'name': 'CRS'
 		},
 		{
-			"id": 4,
-			"name": "Umbrella"
+			'id': 4,
+			'name': 'Umbrella'
 		},
 		{
-			"id": 10,
-			"name": "Pierce and Pierce"
+			'id': 10,
+			'name': 'Pierce and Pierce'
 		},
 		{
-			"id": 8,
-			"name": "Aperture"
+			'id': 8,
+			'name': 'Aperture'
 		}
 	]
 };

--- a/src/lib/portal.js
+++ b/src/lib/portal.js
@@ -1,5 +1,5 @@
-import config from "./config";
-import Promise from "promise-polyfill";
+import config from './config';
+import Promise from 'promise-polyfill';
 
 const PORTAL_LOAD_TIMEOUT_MILLISECONDS = 5000;
 const PORTAL_COMMAND_TIMEOUT_MILLISECONDS = 2000;

--- a/src/lib/store.js
+++ b/src/lib/store.js
@@ -1,4 +1,4 @@
-import { writePublisherConsentCookie, writeVendorConsentCookie } from "./cookie/cookie";
+import { writePublisherConsentCookie, writeVendorConsentCookie } from './cookie/cookie';
 import config from './config';
 import { findLocale } from './localize';
 

--- a/src/lib/store.test.js
+++ b/src/lib/store.test.js
@@ -5,50 +5,50 @@ import Store from './store';
 
 
 const vendorList = {
-	"version": 1,
-	"origin": "http://ib.adnxs.com/vendors.json",
-	"purposes": [
+	'version': 1,
+	'origin': 'http://ib.adnxs.com/vendors.json',
+	'purposes': [
 		{
-			"id": 1,
-			"name": "Accessing a Device or Browser"
+			'id': 1,
+			'name': 'Accessing a Device or Browser'
 		},
 		{
-			"id": 2,
-			"name": "Advertising Personalisation"
+			'id': 2,
+			'name': 'Advertising Personalisation'
 		},
 		{
-			"id": 3,
-			"name": "Analytics"
+			'id': 3,
+			'name': 'Analytics'
 		},
 		{
-			"id": 4,
-			"name": "Content Personalisation"
+			'id': 4,
+			'name': 'Content Personalisation'
 		}
 	],
-	"vendors": [
+	'vendors': [
 		{
-			"id": 1,
-			"name": "Globex"
+			'id': 1,
+			'name': 'Globex'
 		},
 		{
-			"id": 2,
-			"name": "Initech"
+			'id': 2,
+			'name': 'Initech'
 		},
 		{
-			"id": 3,
-			"name": "CRS"
+			'id': 3,
+			'name': 'CRS'
 		},
 		{
-			"id": 4,
-			"name": "Umbrella"
+			'id': 4,
+			'name': 'Umbrella'
 		},
 		{
-			"id": 5,
-			"name": "Aperture"
+			'id': 5,
+			'name': 'Aperture'
 		},
 		{
-			"id": 6,
-			"name": "Pierce and Pierce"
+			'id': 6,
+			'name': 'Pierce and Pierce'
 		}
 	]
 };

--- a/src/lib/translations.js
+++ b/src/lib/translations.js
@@ -10,7 +10,7 @@ export default {
 	en: {
 		banner: {
 			title: 'Privacy Choices',
-			description: `By using this site, you agree to our use of cookies and information to provide personalized content and ads and measure and analyze site usage. Click "Learn More" to change your settings.`,
+			description: 'By using this site, you agree to our use of cookies and information to provide personalized content and ads and measure and analyze site usage. Click "Learn More" to change your settings.',
 			links: {
 				data: {
 					title: 'Information that may be used',
@@ -61,7 +61,7 @@ export default {
 			title: '',
 			description: '',
 			back: '',
-			optoutdDescription: ``,
+			optoutdDescription: '',
 			purpose1: {
 				description:
 					'Allow storing or accessing information on a user’s device.'
@@ -94,7 +94,7 @@ export default {
 				</ul>`
 			},
 			purpose5: {
-				description: `The collection of information about your use of the content, and combination with previously collected information, used to measure, understand, and report on your usage of the service. This does not include personalisation, the collection of information about your use of this service to subsequently personalise content and/or advertising for you in other contexts, i.e. on other service, such as websites or apps, over time.`
+				description: 'The collection of information about your use of the content, and combination with previously collected information, used to measure, understand, and report on your usage of the service. This does not include personalisation, the collection of information about your use of this service to subsequently personalise content and/or advertising for you in other contexts, i.e. on other service, such as websites or apps, over time.'
 			},
 			purpose10: {
 				title: '',
@@ -148,7 +148,7 @@ export default {
 				},
 				purposes: {
 					title: 'Propósitos para almacenar información.',
-					description: `Cómo puede ser usada la información:`
+					description: 'Cómo puede ser usada la información:'
 				},
 				manage: 'Leer más',
 				accept: 'Aceptar'
@@ -253,7 +253,7 @@ export default {
 				},
 				purposes: {
 					title: 'Utilisation des données',
-					description: `A quoi servent ces données:`
+					description: 'A quoi servent ces données:'
 				},
 				manage: 'Préférences',
 				accept: 'Continuer'
@@ -262,7 +262,7 @@ export default {
 		summary: {
 			title: 'Comment sont utilisées mes données ?',
 			description:
-				"Nos partenaires et nous-même utilisons les cookies (petits fichiers texte) du navigateur afin de comprendre les centres d'intérêt de nos visiteurs et ainsi leur proposer du contenu et de la publicité pertinents. Désormais, nous avons besoin de votre consentement.",
+				'Nos partenaires et nous-même utilisons les cookies (petits fichiers texte) du navigateur afin de comprendre les centres d\'intérêt de nos visiteurs et ainsi leur proposer du contenu et de la publicité pertinents. Désormais, nous avons besoin de votre consentement.',
 			detailLink: 'Informations et configuration',
 			who: {
 				title: 'Qui utilise mes données ?',
@@ -295,8 +295,8 @@ export default {
 						<li>Informations de géolocalisation de l'appareil lorsqu'il accède au site Web</li>
 					</ul>`,
 			purpose1: {
-				menu: "Stockage d'informations et accès",
-				title: "Stockage d'informations et accès",
+				menu: 'Stockage d\'informations et accès',
+				title: 'Stockage d\'informations et accès',
 				description:
 					'Autoriser le stockage d’informations ou l’accès à des informations déjà stockées sur votre appareil, telles que des identifiants publicitaires, des identifiants de dispositif, des cookies et des technologies similaires.'
 			},
@@ -307,16 +307,16 @@ export default {
 					'Autoriser la collecte et le traitement d’informations sur votre utilisation de ce service pour ensuite personnaliser la publicité et/ou le contenu qui vous sont proposés dans d’autres contextes, tels que sur d’autres sites ou applications, au fil du temps. En règle générale, le contenu du site ou de l’application est utilisé pour déterminer vos centres d’intérêt et permettent de déterminer le choix de la publicité et/ou du contenu.'
 			},
 			purpose3: {
-				menu: "Sélection d'annonces, diffusion, rapport",
-				title: "Sélection d'annonces, diffusion, rapport",
+				menu: 'Sélection d\'annonces, diffusion, rapport',
+				title: 'Sélection d\'annonces, diffusion, rapport',
 				description:
-					"Autoriser le traitement des données d'un utilisateur pour fournir du contenu ou des publicités et mesurer la diffusion de ces contenus ou publicités, extraire des informations et générer des rapports pour comprendre l'utilisation des services; et / ou accéder ou stocker des informations sur des dispositifs à cette fin. Inclura les caractéristiques suivantes:"
+					'Autoriser le traitement des données d\'un utilisateur pour fournir du contenu ou des publicités et mesurer la diffusion de ces contenus ou publicités, extraire des informations et générer des rapports pour comprendre l\'utilisation des services; et / ou accéder ou stocker des informations sur des dispositifs à cette fin. Inclura les caractéristiques suivantes:'
 			},
 			purpose4: {
 				menu: 'Sélection de contenu, diffusion, rapport',
 				title: 'Sélection de contenu, diffusion, rapport',
 				description:
-					"Autoriser le traitement des données d'un utilisateur pour la création de contenu personnalisé (y compris la diffusion, l'analyse et la création de rapports) en fonction des préférences ou des intérêts d'un utilisateur connus ou inférer à partir de données collectées sur plusieurs sites, applications ou appareils; et / ou accéder ou stocker des informations sur des dispositifs à cette fin. Inclura les caractéristiques suivantes:"
+					'Autoriser le traitement des données d\'un utilisateur pour la création de contenu personnalisé (y compris la diffusion, l\'analyse et la création de rapports) en fonction des préférences ou des intérêts d\'un utilisateur connus ou inférer à partir de données collectées sur plusieurs sites, applications ou appareils; et / ou accéder ou stocker des informations sur des dispositifs à cette fin. Inclura les caractéristiques suivantes:'
 			},
 			purpose5: {
 				menu: 'Mesures',
@@ -355,7 +355,7 @@ export default {
 				},
 				purposes: {
 					title: 'Verwendung von Daten',
-					description: `Wozu dienen diese Daten?`
+					description: 'Wozu dienen diese Daten?'
 				},
 				manage: 'Einstellungen',
 				accept: 'Akzeptieren und fortsetzen'
@@ -368,7 +368,7 @@ export default {
 			detailLink: 'Informationen und Einstellungen',
 			who: {
 				title: 'Wer nutzt meine Daten?',
-				description: `Nur unsere Partner und wir können Ihre Daten verwenden. Sie können Ihre Auswahl oben anpassen oder unsere Website weiterhin nutzen, wenn Sie zustimmen.`,
+				description: 'Nur unsere Partner und wir können Ihre Daten verwenden. Sie können Ihre Auswahl oben anpassen oder unsere Website weiterhin nutzen, wenn Sie zustimmen.',
 				link: 'Sehen Sie die komplette Liste unserer Partner'
 			},
 			what: {
@@ -456,7 +456,7 @@ export default {
 				},
 				purposes: {
 					title: 'Cele przechowywania informacji.',
-					description: `W jaki sposób informacje mogą być używane:`
+					description: 'W jaki sposób informacje mogą być używane:'
 				},
 				manage: 'Zobacz więcej',
 				accept: '<b>Akceptuję</b>'
@@ -566,7 +566,7 @@ export default {
 				},
 				purposes: {
 					title: 'Uso dei dati.',
-					description: `Come possono essere utilizzate le informazioni:`
+					description: 'Come possono essere utilizzate le informazioni:'
 				},
 				manage: 'Leggi di più',
 				accept: 'Accetta'
@@ -581,24 +581,24 @@ export default {
 			title:
 				'Ulteriori informazioni su come vengono utilizzate le informazioni.',
 			description:
-				"Noi e alcune società selezionate possiamo accedere e utilizzare le tue informazioni per i seguenti scopi. Puoi personalizzare le tue opzioni qui sotto o continuare a utilizzare il nostro sito se sei d'accordo con gli scopi.",
+				'Noi e alcune società selezionate possiamo accedere e utilizzare le tue informazioni per i seguenti scopi. Puoi personalizzare le tue opzioni qui sotto o continuare a utilizzare il nostro sito se sei d\'accordo con gli scopi.',
 			detailLink: 'Maggiori informazioni',
 			who: {
 				title: 'Chi sta usando queste informazioni?',
 				description:
 					'Noi e le società preselezionate utilizziamo le tue informazioni. Puoi vedere ciascuna compagnia nei link sopra.',
-				link: "Guarda l'elenco completo qui."
+				link: 'Guarda l\'elenco completo qui.'
 			},
 			what: {
 				title: 'Quali informazioni vengono utilizzate?',
 				description: 'Diverse aziende usano informazioni diverse,',
-				link: "Guarda l'elenco completo qui."
+				link: 'Guarda l\'elenco completo qui.'
 			}
 		},
 		purposes: {
 			title: 'Dati raccolti',
 			description:
-				"Di seguito è riportato l'elenco dei dati che possono essere raccolti:",
+				'Di seguito è riportato l\'elenco dei dati che possono essere raccolti:',
 			back: 'Configura come vengono utilizzati questi dati',
 			optoutdDescription:
 				'A seconda del tipo di dati che raccolgono, utilizzano e elaborano, e di altri fattori, inclusa la privacy in base alla progettazione, alcuni partner fanno affidamento sul loro consenso, mentre altri richiedono che vengano esclusi. Per informazioni su ciascun fornitore ed esercitare le tue scelte, vedi sotto. O per rinunciare, visitare i siti NAI, DAA o EDAA.',
@@ -615,31 +615,31 @@ export default {
 				menu: 'Archiviazione e accesso alle informazioni',
 				title: 'Archiviazione e accesso alle informazioni',
 				description:
-					"La memorizzazione e l'accesso alle informazioni già memorizzate sul dispositivo, come identificatori pubblicitari, identificativi del dispositivo, cookie e tecnologie simili."
+					'La memorizzazione e l\'accesso alle informazioni già memorizzate sul dispositivo, come identificatori pubblicitari, identificativi del dispositivo, cookie e tecnologie simili.'
 			},
 			purpose2: {
 				menu: 'Personalizzazione',
 				title: 'Personalizzazione',
 				description:
-					"La raccolta e l'elaborazione di informazioni per personalizzare successivamente la pubblicità e / o il contenuto per te, come in altri siti Web o applicazioni, nel tempo. Normalmente, la futura selezione di pubblicità e / o contenuti."
+					'La raccolta e l\'elaborazione di informazioni per personalizzare successivamente la pubblicità e / o il contenuto per te, come in altri siti Web o applicazioni, nel tempo. Normalmente, la futura selezione di pubblicità e / o contenuti.'
 			},
 			purpose3: {
 				menu: 'Selezione degli annunci, diffusione, report',
 				title: 'Selezione degli annunci, diffusione, report',
 				description:
-					"Consentire l'elaborazione dei dati di un utente per fornire contenuti o annunci pubblicitari e misurare la diffusione di tali contenuti o pubblicità, estrarre informazioni e generare rapporti per comprendere l'uso dei servizi; e / o accedere o memorizzare informazioni sui dispositivi per questo scopo. Includi le seguenti funzionalità."
+					'Consentire l\'elaborazione dei dati di un utente per fornire contenuti o annunci pubblicitari e misurare la diffusione di tali contenuti o pubblicità, estrarre informazioni e generare rapporti per comprendere l\'uso dei servizi; e / o accedere o memorizzare informazioni sui dispositivi per questo scopo. Includi le seguenti funzionalità.'
 			},
 			purpose4: {
 				menu: 'Selezione dei contenuti, diffusione, report',
 				title: 'Selezione dei contenuti, diffusione, report',
 				description:
-					"Raccolta di informazioni e combinazione con informazioni precedentemente raccolte per selezionare e fornire contenuti per te e per misurare la consegna e l'efficacia di tali contenuti. Ciò include l'uso delle informazioni raccolte in precedenza sui tuoi interessi per selezionare il contenuto, elaborare i dati su quale contenuto è stato visualizzato, con quale frequenza o per quanto tempo è stato mostrato, quando e dove è stato visualizzato e se hai intrapreso qualche azione relativa al contenuto, incluso esempio, clic sul contenuto. Ciò non include la personalizzazione, che è la raccolta e l'elaborazione di informazioni sull'uso di questo servizio per personalizzare successivamente il contenuto e / o la pubblicità in altri contesti, come siti Web o applicazioni, nel tempo."
+					'Raccolta di informazioni e combinazione con informazioni precedentemente raccolte per selezionare e fornire contenuti per te e per misurare la consegna e l\'efficacia di tali contenuti. Ciò include l\'uso delle informazioni raccolte in precedenza sui tuoi interessi per selezionare il contenuto, elaborare i dati su quale contenuto è stato visualizzato, con quale frequenza o per quanto tempo è stato mostrato, quando e dove è stato visualizzato e se hai intrapreso qualche azione relativa al contenuto, incluso esempio, clic sul contenuto. Ciò non include la personalizzazione, che è la raccolta e l\'elaborazione di informazioni sull\'uso di questo servizio per personalizzare successivamente il contenuto e / o la pubblicità in altri contesti, come siti Web o applicazioni, nel tempo.'
 			},
 			purpose5: {
 				menu: 'Misurazione',
 				title: 'Misurazione',
 				description:
-					"Raccolta di informazioni sull'utilizzo del contenuto e sulla combinazione di informazioni raccolte in precedenza, utilizzate per misurare, comprendere e riferire sull'utilizzo del servizio. Ciò non include la personalizzazione, la raccolta di informazioni sull'uso di questo servizio per personalizzare successivamente il contenuto e / o la pubblicità in altri contesti, ovvero in altri servizi, come siti Web o applicazioni, nel tempo."
+					'Raccolta di informazioni sull\'utilizzo del contenuto e sulla combinazione di informazioni raccolte in precedenza, utilizzate per misurare, comprendere e riferire sull\'utilizzo del servizio. Ciò non include la personalizzazione, la raccolta di informazioni sull\'uso di questo servizio per personalizzare successivamente il contenuto e / o la pubblicità in altri contesti, ovvero in altri servizi, come siti Web o applicazioni, nel tempo.'
 			}
 		},
 		vendors: {

--- a/src/s1/cmp.js
+++ b/src/s1/cmp.js
@@ -1,18 +1,18 @@
 // __cmp('setConsentUiCallback', callback) QUANTCAST
-import 'core-js/fn/array/find-index';
-import 'core-js/fn/array/filter';
-import 'core-js/fn/array/from';
-import 'core-js/fn/array/find';
-import 'core-js/fn/array/map';
-import 'core-js/fn/object/keys';
-import 'core-js/fn/promise';
+import "core-js/fn/array/find-index";
+import "core-js/fn/array/filter";
+import "core-js/fn/array/from";
+import "core-js/fn/array/find";
+import "core-js/fn/array/map";
+import "core-js/fn/object/keys";
+import "core-js/fn/promise";
 
-import cmp from '../loader';
-import {init, getStore} from '../lib/init';
-import log from '../lib/log';
-import {readCookie, writeCookie} from '../lib/cookie/cookie';
+import cmp from "../loader";
+import { init } from "../lib/init";
+import log from "../lib/log";
+import { readCookie, writeCookie } from "../lib/cookie/cookie";
 
-const GDPR_OPT_IN_COOKIE = 'gdpr_opt_in';
+const GDPR_OPT_IN_COOKIE = "gdpr_opt_in";
 const GDPR_OPT_IN_COOKIE_MAX_AGE = 33696000;
 
 const defaultConfig = {
@@ -23,11 +23,11 @@ const defaultConfig = {
 };
 
 const addLocatorFrame = () => {
-	if (!window.frames['__cmpLocator']) {
+	if (!window.frames["__cmpLocator"]) {
 		if (document.body) {
-			const frame = document.createElement('iframe');
-			frame.style.display = 'none';
-			frame.name = '__cmpLocator';
+			const frame = document.createElement("iframe");
+			frame.style.display = "none";
+			frame.name = "__cmpLocator";
 			document.body.appendChild(frame);
 		} else {
 			setTimeout(addLocatorFrame, 5);
@@ -39,13 +39,13 @@ const addPostmessageReceiver = cmp => {
 	const onReceiveMessage = event => {
 		const data = event && event.data && event.data.__cmpCall;
 		if (data) {
-			const {command, parameter} = data;
+			const { command, parameter } = data;
 			cmp.call(this, command, parameter);
 		}
 	};
 
 	const listen = window.attachEvent || window.addEventListener;
-	listen('message', onReceiveMessage, false);
+	listen("message", onReceiveMessage, false);
 };
 
 const initialize = (config, callback) => {
@@ -57,7 +57,7 @@ const initialize = (config, callback) => {
 		addPostmessageReceiver(cmp);
 		addLocatorFrame();
 
-		cmp('addEventListener', 'onSubmit', () => {
+		cmp("addEventListener", "onSubmit", () => {
 			checkConsent();
 		});
 
@@ -69,11 +69,11 @@ const initialize = (config, callback) => {
 };
 
 const checkHasConsentedAll = (
-	{vendors = []},
-	{purposeConsents, vendorConsents} = {}
+	{ vendors = [] },
+	{ purposeConsents, vendorConsents } = {}
 ) => {
 	const hasAnyVendorsDisabled = vendors.find(
-		({id}) => vendorConsents[id] === false
+		({ id }) => vendorConsents[id] === false
 	);
 	const hasAnyPurposeDisabled = Object.keys(purposeConsents).find(key => {
 		return purposeConsents[key] === false;
@@ -81,25 +81,29 @@ const checkHasConsentedAll = (
 	return !hasAnyPurposeDisabled && !hasAnyVendorsDisabled;
 };
 
-const checkConsent = ({callback = () => {}, config, warningMsg = ''} = {}) => {
-	let errorMsg = '';
+const checkConsent = ({
+	callback = () => {},
+	config,
+	warningMsg = ""
+} = {}) => {
+	let errorMsg = "";
 	if (!cmp.isLoaded) {
-		errorMsg = 'CMP failed to load';
+		errorMsg = "CMP failed to load";
 		log.error(errorMsg);
 		handleConsentResult({
 			errorMsg,
 			warningMsg
 		});
 	} else if (!window.navigator.cookieEnabled) {
-		errorMsg = 'Cookies are disabled. Ignoring CMP consent check';
+		errorMsg = "Cookies are disabled. Ignoring CMP consent check";
 		log.error(errorMsg);
 		handleConsentResult({
 			errorMsg,
 			warningMsg
 		});
 	} else {
-		cmp('getVendorList', null, vendorList => {
-			cmp('getVendorConsents', null, vendorConsentData => {
+		cmp("getVendorList", null, vendorList => {
+			cmp("getVendorConsents", null, vendorConsentData => {
 				handleConsentResult({
 					vendorList,
 					vendorConsentData,
@@ -117,17 +121,19 @@ const handleConsentResult = ({
 	vendorConsentData = {},
 	callback,
 	config,
-	warningMsg = '',
-	errorMsg = ''
+	warningMsg = "",
+	errorMsg = ""
 }) => {
-	const hasConsentedCookie = !!readCookie(GDPR_OPT_IN_COOKIE);
-	const {vendorListVersion: listVersion} = vendorList;
-	const {created, vendorListVersion} = vendorConsentData;
+	const hasConsentedCookie = Boolean(
+		parseInt(readCookie(GDPR_OPT_IN_COOKIE) || 0, 10)
+	);
+	const { vendorListVersion: listVersion } = vendorList;
+	const { created, vendorListVersion } = vendorConsentData;
 
-	const autoConsentFlow = (shouldAutoConsentWithFooter, warningMsg = '') => {
-		cmp('acceptAllConsents');
+	const autoConsentFlow = (shouldAutoConsentWithFooter, warningMsg = "") => {
+		cmp("acceptAllConsents");
 		if (shouldAutoConsentWithFooter) {
-			cmp('showConsentTool');
+			cmp("showConsentTool");
 		}
 		checkConsent({
 			callback,
@@ -136,15 +142,15 @@ const handleConsentResult = ({
 	};
 
 	if (!created) {
-		const {shouldAutoConsent, shouldAutoConsentWithFooter} = config || {};
+		const { shouldAutoConsent, shouldAutoConsentWithFooter } = config || {};
 		if (shouldAutoConsent || shouldAutoConsentWithFooter) {
-			log.debug('CMP: auto-consent to all conditions.');
+			log.debug("CMP: auto-consent to all conditions.");
 			autoConsentFlow(shouldAutoConsentWithFooter);
 			return;
 		}
-		errorMsg = 'No consent data found. Show consent tool';
+		errorMsg = "No consent data found. Show consent tool";
 	} else if (vendorListVersion !== listVersion) {
-		const {shouldAutoUpgradeConsent} = config || {};
+		const { shouldAutoUpgradeConsent } = config || {};
 		if (shouldAutoUpgradeConsent) {
 			warningMsg = `Consent found for version ${vendorListVersion}, but received vendor list version ${listVersion}. Consent upgraded, show consent notice`;
 			log.debug(warningMsg);
@@ -154,20 +160,20 @@ const handleConsentResult = ({
 		errorMsg = `Consent found for version ${vendorListVersion}, but received vendor list version ${listVersion}. Show consent tool`;
 	} else if (!listVersion) {
 		errorMsg =
-			'Could not determine vendor list version. Not showing consent tool';
+			"Could not determine vendor list version. Not showing consent tool";
 	}
 
 	if (errorMsg) {
 		log.debug(errorMsg);
 	}
 
-	if (callback && typeof callback === 'function') {
+	if (callback && typeof callback === "function") {
 		// store as 1 or 0
 		const hasConsented = checkHasConsentedAll(vendorList, vendorConsentData);
 		if (created) {
 			writeCookie(
 				GDPR_OPT_IN_COOKIE,
-				hasConsented ? '1' : '0',
+				hasConsented ? "1" : "0",
 				GDPR_OPT_IN_COOKIE_MAX_AGE
 			);
 		}
@@ -181,11 +187,11 @@ const handleConsentResult = ({
 			warningMsg
 		};
 
-		callback.call(this, consent);
-
 		if (created && hasConsented !== hasConsentedCookie && !errorMsg) {
-			cmp.notify('onConsentChanged', consent);
+			cmp.notify("onConsentChanged", consent);
 		}
+
+		callback.call(this, consent);
 	}
 };
 
@@ -193,13 +199,13 @@ const handleConsentResult = ({
 (() => {
 	const initIndex =
 		cmp.commandQueue &&
-		cmp.commandQueue.findIndex(({command}) => {
-			return command === 'init';
+		cmp.commandQueue.findIndex(({ command }) => {
+			return command === "init";
 		});
 
 	// 1. initialize call was queued from global scope (inline cmpLoader)
 	if (initIndex >= 0 && cmp.commandQueue[initIndex]) {
-		const [{parameter: config, callback}] = cmp.commandQueue.splice(
+		const [{ parameter: config, callback }] = cmp.commandQueue.splice(
 			initIndex,
 			1
 		); // remove "init" from command list because it doesn't exist
@@ -214,10 +220,10 @@ const handleConsentResult = ({
 		// 2. initialize call never queued, so initialize with default Config
 	} else {
 		initialize(defaultConfig, result => {
-			const {errorMsg} = result;
+			const { errorMsg } = result;
 			if (errorMsg) {
 				log.debug(errorMsg);
-				cmp('showConsentTool');
+				cmp("showConsentTool");
 			}
 		});
 	}

--- a/src/s1/cmp.js
+++ b/src/s1/cmp.js
@@ -1,18 +1,18 @@
 // __cmp('setConsentUiCallback', callback) QUANTCAST
-import "core-js/fn/array/find-index";
-import "core-js/fn/array/filter";
-import "core-js/fn/array/from";
-import "core-js/fn/array/find";
-import "core-js/fn/array/map";
-import "core-js/fn/object/keys";
-import "core-js/fn/promise";
+import 'core-js/fn/array/find-index';
+import 'core-js/fn/array/filter';
+import 'core-js/fn/array/from';
+import 'core-js/fn/array/find';
+import 'core-js/fn/array/map';
+import 'core-js/fn/object/keys';
+import 'core-js/fn/promise';
 
-import cmp from "../loader";
-import { init } from "../lib/init";
-import log from "../lib/log";
-import { readCookie, writeCookie } from "../lib/cookie/cookie";
+import cmp from '../loader';
+import { init } from '../lib/init';
+import log from '../lib/log';
+import { readCookie, writeCookie } from '../lib/cookie/cookie';
 
-const GDPR_OPT_IN_COOKIE = "gdpr_opt_in";
+const GDPR_OPT_IN_COOKIE = 'gdpr_opt_in';
 const GDPR_OPT_IN_COOKIE_MAX_AGE = 33696000;
 
 const defaultConfig = {
@@ -23,11 +23,11 @@ const defaultConfig = {
 };
 
 const addLocatorFrame = () => {
-	if (!window.frames["__cmpLocator"]) {
+	if (!window.frames['__cmpLocator']) {
 		if (document.body) {
-			const frame = document.createElement("iframe");
-			frame.style.display = "none";
-			frame.name = "__cmpLocator";
+			const frame = document.createElement('iframe');
+			frame.style.display = 'none';
+			frame.name = '__cmpLocator';
 			document.body.appendChild(frame);
 		} else {
 			setTimeout(addLocatorFrame, 5);
@@ -45,7 +45,7 @@ const addPostmessageReceiver = cmp => {
 	};
 
 	const listen = window.attachEvent || window.addEventListener;
-	listen("message", onReceiveMessage, false);
+	listen('message', onReceiveMessage, false);
 };
 
 const initialize = (config, callback) => {
@@ -57,7 +57,7 @@ const initialize = (config, callback) => {
 		addPostmessageReceiver(cmp);
 		addLocatorFrame();
 
-		cmp("addEventListener", "onSubmit", () => {
+		cmp('addEventListener', 'onSubmit', () => {
 			checkConsent();
 		});
 
@@ -84,26 +84,26 @@ const checkHasConsentedAll = (
 const checkConsent = ({
 	callback = () => {},
 	config,
-	warningMsg = ""
+	warningMsg = ''
 } = {}) => {
-	let errorMsg = "";
+	let errorMsg = '';
 	if (!cmp.isLoaded) {
-		errorMsg = "CMP failed to load";
+		errorMsg = 'CMP failed to load';
 		log.error(errorMsg);
 		handleConsentResult({
 			errorMsg,
 			warningMsg
 		});
 	} else if (!window.navigator.cookieEnabled) {
-		errorMsg = "Cookies are disabled. Ignoring CMP consent check";
+		errorMsg = 'Cookies are disabled. Ignoring CMP consent check';
 		log.error(errorMsg);
 		handleConsentResult({
 			errorMsg,
 			warningMsg
 		});
 	} else {
-		cmp("getVendorList", null, vendorList => {
-			cmp("getVendorConsents", null, vendorConsentData => {
+		cmp('getVendorList', null, vendorList => {
+			cmp('getVendorConsents', null, vendorConsentData => {
 				handleConsentResult({
 					vendorList,
 					vendorConsentData,
@@ -121,8 +121,8 @@ const handleConsentResult = ({
 	vendorConsentData = {},
 	callback,
 	config,
-	warningMsg = "",
-	errorMsg = ""
+	warningMsg = '',
+	errorMsg = ''
 }) => {
 	const hasConsentedCookie = Boolean(
 		parseInt(readCookie(GDPR_OPT_IN_COOKIE) || 0, 10)
@@ -130,10 +130,10 @@ const handleConsentResult = ({
 	const { vendorListVersion: listVersion } = vendorList;
 	const { created, vendorListVersion } = vendorConsentData;
 
-	const autoConsentFlow = (shouldAutoConsentWithFooter, warningMsg = "") => {
-		cmp("acceptAllConsents");
+	const autoConsentFlow = (shouldAutoConsentWithFooter, warningMsg = '') => {
+		cmp('acceptAllConsents');
 		if (shouldAutoConsentWithFooter) {
-			cmp("showConsentTool");
+			cmp('showConsentTool');
 		}
 		checkConsent({
 			callback,
@@ -144,11 +144,11 @@ const handleConsentResult = ({
 	if (!created) {
 		const { shouldAutoConsent, shouldAutoConsentWithFooter } = config || {};
 		if (shouldAutoConsent || shouldAutoConsentWithFooter) {
-			log.debug("CMP: auto-consent to all conditions.");
+			log.debug('CMP: auto-consent to all conditions.');
 			autoConsentFlow(shouldAutoConsentWithFooter);
 			return;
 		}
-		errorMsg = "No consent data found. Show consent tool";
+		errorMsg = 'No consent data found. Show consent tool';
 	} else if (vendorListVersion !== listVersion) {
 		const { shouldAutoUpgradeConsent } = config || {};
 		if (shouldAutoUpgradeConsent) {
@@ -160,20 +160,20 @@ const handleConsentResult = ({
 		errorMsg = `Consent found for version ${vendorListVersion}, but received vendor list version ${listVersion}. Show consent tool`;
 	} else if (!listVersion) {
 		errorMsg =
-			"Could not determine vendor list version. Not showing consent tool";
+			'Could not determine vendor list version. Not showing consent tool';
 	}
 
 	if (errorMsg) {
 		log.debug(errorMsg);
 	}
 
-	if (callback && typeof callback === "function") {
+	if (callback && typeof callback === 'function') {
 		// store as 1 or 0
 		const hasConsented = checkHasConsentedAll(vendorList, vendorConsentData);
 		if (created) {
 			writeCookie(
 				GDPR_OPT_IN_COOKIE,
-				hasConsented ? "1" : "0",
+				hasConsented ? '1' : '0',
 				GDPR_OPT_IN_COOKIE_MAX_AGE
 			);
 		}
@@ -188,7 +188,7 @@ const handleConsentResult = ({
 		};
 
 		if (created && hasConsented !== hasConsentedCookie && !errorMsg) {
-			cmp.notify("onConsentChanged", consent);
+			cmp.notify('onConsentChanged', consent);
 		}
 
 		callback.call(this, consent);
@@ -200,7 +200,7 @@ const handleConsentResult = ({
 	const initIndex =
 		cmp.commandQueue &&
 		cmp.commandQueue.findIndex(({ command }) => {
-			return command === "init";
+			return command === 'init';
 		});
 
 	// 1. initialize call was queued from global scope (inline cmpLoader)
@@ -223,7 +223,7 @@ const handleConsentResult = ({
 			const { errorMsg } = result;
 			if (errorMsg) {
 				log.debug(errorMsg);
-				cmp("showConsentTool");
+				cmp('showConsentTool');
 			}
 		});
 	}

--- a/src/s1cmp.hbs
+++ b/src/s1cmp.hbs
@@ -28,7 +28,7 @@
 			globalConsentLocation: 'https://s.flocdn.com/cmp/docs/portal.html',
 			storeConsentGlobally: false,
 			// localization: {},
-			// forceLocale: null,
+			// forceLocale: 'es',
 			theme: {
 				isBannerModal: true
 			},

--- a/src/s1cmp.hbs
+++ b/src/s1cmp.hbs
@@ -35,15 +35,16 @@
 			gdprApplies: true,
 			// allowedVendorIds: null,
 			shouldAutoConsent: false,
-			shouldAutoConsentWithFooter: false
+			shouldAutoConsentWithFooter: true
 		}
 
 		function onConsentChanged(result) {
+			console.log('result', result)
 			if (document.cookie.indexOf("gdpr_opt_in=1") < 0) {
-				console.log("cmp:all-consent:failed", result);
+				console.log("cmp:onConsentChanged all-consent:failed", result);
 				// window.location.reload();
 			} else {
-				console.log("cmp:all-consent:succeeded", result);
+				console.log("cmp:onConsentChanged all-consent:succeeded", result);
 			}
 		}
 
@@ -55,7 +56,6 @@
 				if (result.errorMsg) {
 					console.log('cmp:init: errorMsg', result.errorMsg);
 					cmp('showConsentTool');
-					cmp('addEventListener', 'onConsentChanged', onConsentChanged);
 				} else {
 					// consent achieved
 					if (document.cookie.indexOf("gdpr_opt_in=1") >= 0) {
@@ -63,8 +63,10 @@
 					} else {
 						console.log("cmp:init: only some consent achieved", result);
 					}
-					cmp('addEventListener', 'onConsentChanged', onConsentChanged);
 				}
+				setTimeout(() => {
+					cmp('addEventListener', 'onConsentChanged', onConsentChanged);
+				}, 0);
 			} else {
 				console.log("cmp:init: consent not required", result);
 			}

--- a/src/s1cmp.hbs
+++ b/src/s1cmp.hbs
@@ -39,7 +39,6 @@
 		}
 
 		function onConsentChanged(result) {
-			console.log('result', result)
 			if (document.cookie.indexOf("gdpr_opt_in=1") < 0) {
 				console.log("cmp:onConsentChanged all-consent:failed", result);
 				// window.location.reload();
@@ -64,9 +63,7 @@
 						console.log("cmp:init: only some consent achieved", result);
 					}
 				}
-				setTimeout(() => {
-					cmp('addEventListener', 'onConsentChanged', onConsentChanged);
-				}, 0);
+				cmp('addEventListener', 'onConsentChanged', onConsentChanged);
 			} else {
 				console.log("cmp:init: consent not required", result);
 			}

--- a/src/test/helpers.js
+++ b/src/test/helpers.js
@@ -1,26 +1,26 @@
-export const deleteAllCookies = (domain = "") => {
-	let cookies = document.cookie.split(";");
+export const deleteAllCookies = (domain = '') => {
+	let cookies = document.cookie.split(';');
 
 	for (let i = 0; i < cookies.length; i++) {
 		let cookie = cookies[i];
-		let eqPos = cookie.indexOf("=");
+		let eqPos = cookie.indexOf('=');
 		let name = eqPos > -1 ? cookie.substr(0, eqPos) : cookie;
 		document.cookie = name + `=;${domain}expires=Thu, 01 Jan 1970 00:00:00 GMT`;
 	}
 };
 
 export const setCookie = (
-	name = "",
-	value = "",
+	name = '',
+	value = '',
 	expires = 30000,
-	path = "/"
+	path = '/'
 ) => {
 	document.cookie = `${name}=${value}; expires=${Date.now() +
 		expires}; path=${path}`;
 };
 
 // pre 1.0.0 consent (old modal consent string)
-export const oldEuconsentCookie = `BOm168dOm168dABABAENCl-AAAAqV7_______9______9uz_Ov_v_f__33e8__9v_l_7_-___u_-3zd4u_1vf99yfm1-7etr3tp_87ues2_Xur__79__3z3_9phP78k89r7337Ew-v-3o8A`;
+export const oldEuconsentCookie = 'BOm168dOm168dABABAENCl-AAAAqV7_______9______9uz_Ov_v_f__33e8__9v_l_7_-___u_-3zd4u_1vf99yfm1-7etr3tp_87ues2_Xur__79__3z3_9phP78k89r7337Ew-v-3o8A';
 
 // post 1.0.0 consent string (contains vendorList id)
-export const newEuconsentCookie = `BOm1-IOOm1-IOAmABAENCl-AAAAqV7_______9______9uz_Ov_v_f__33e8__9v_l_7_-___u_-3zd4u_1vf99yfm1-7etr3tp_87ues2_Xur__79__3z3_9phP78k89r7337Ew-v-3o8A`;
+export const newEuconsentCookie = 'BOm1-IOOm1-IOAmABAENCl-AAAAqV7_______9______9uz_Ov_v_f__33e8__9v_l_7_-___u_-3zd4u_1vf99yfm1-7etr3tp_87ues2_Xur__79__3z3_9phP78k89r7337Ew-v-3o8A';

--- a/src/test/loader.inline.test.js
+++ b/src/test/loader.inline.test.js
@@ -1,106 +1,106 @@
 /* eslint-disable max-nested-callbacks */
 /* eslint-disable no-eval */
 
-import { expect } from "chai";
-import fs from "fs";
-import vendorlist from "../docs/assets/vendorlist.json";
-import { COOKIE_DOMAIN } from "../lib/cookie/cookie";
-import { deleteAllCookies, setCookie, oldEuconsentCookie } from "./helpers";
+import { expect } from 'chai';
+import fs from 'fs';
+import vendorlist from '../docs/assets/vendorlist.json';
+import { COOKIE_DOMAIN } from '../lib/cookie/cookie';
+import { deleteAllCookies, setCookie, oldEuconsentCookie } from './helpers';
 
-const fakeScriptSrc = "./fake-loader-src.js";
+const fakeScriptSrc = './fake-loader-src.js';
 
-describe("cmpLoader as script tag", () => {
+describe('cmpLoader as script tag', () => {
 	let appendChild;
 
 	beforeEach(() => {
 		appendChild = window.document.body.appendChild = jest.fn(() => {});
-		const content = fs.readFileSync("./src/loader.js");
-		eval(content + "; global.cmp = cmp");
+		const content = fs.readFileSync('./src/loader.js');
+		eval(content + '; global.cmp = cmp');
 	});
 
 	afterEach(() => {
 		deleteAllCookies(COOKIE_DOMAIN);
-		eval("; global.cmp = null; cmp = null;");
+		eval('; global.cmp = null; cmp = null;');
 		jest.restoreAllMocks();
 		appendChild.mockRestore();
 	});
 
-	it("loads cmp as script tag", done => {
+	it('loads cmp as script tag', done => {
 		expect(global.cmp).to.not.be.undefined;
-		expect(typeof global.cmp).to.equal("function");
+		expect(typeof global.cmp).to.equal('function');
 		done();
 	});
 
-	it("warns when no scriptSrc provided", done => {
-		const log = jest.spyOn(window.console, "log");
+	it('warns when no scriptSrc provided', done => {
+		const log = jest.spyOn(window.console, 'log');
 
-		global.cmp("init", {
+		global.cmp('init', {
 			logging: true
 		});
 		expect(log.mock.calls).to.have.length(1);
-		expect(log.mock.calls[0][0]).to.contain("Provide src");
+		expect(log.mock.calls[0][0]).to.contain('Provide src');
 		log.mockRestore();
 		done();
 	});
 
-	it("warns when gdprApplies is false", done => {
-		const log = jest.spyOn(window.console, "log");
-		global.cmp("init", {
+	it('warns when gdprApplies is false', done => {
+		const log = jest.spyOn(window.console, 'log');
+		global.cmp('init', {
 			scriptSrc: fakeScriptSrc,
 			gdprApplies: false,
 			logging: true
 		});
 
 		expect(log.mock.calls).to.have.length(1);
-		expect(log.mock.calls[0][0]).to.contain("gdprApplies turned off so no CMP");
+		expect(log.mock.calls[0][0]).to.contain('gdprApplies turned off so no CMP');
 
 		log.mockRestore();
 		done();
 	});
 
-	it("appends scriptSrc if gdprApplies and scriptSrc provided", done => {
-		const createElement = jest.spyOn(window.document, "createElement");
+	it('appends scriptSrc if gdprApplies and scriptSrc provided', done => {
+		const createElement = jest.spyOn(window.document, 'createElement');
 
-		global.cmp("init", {
+		global.cmp('init', {
 			scriptSrc: fakeScriptSrc,
 			gdprApplies: true
 		});
 
 		expect(createElement.mock.calls).to.have.length(1);
-		expect(createElement.mock.calls[0][0]).to.contain("script");
+		expect(createElement.mock.calls[0][0]).to.contain('script');
 		expect(appendChild.mock.calls).to.have.length(1);
 
 		createElement.mockRestore();
 		done();
 	});
 
-	it("warns on multiple init calls", done => {
-		const log = jest.spyOn(window.console, "log");
-		global.cmp("init", {
+	it('warns on multiple init calls', done => {
+		const log = jest.spyOn(window.console, 'log');
+		global.cmp('init', {
 			scriptSrc: fakeScriptSrc,
 			gdprApplies: true,
 			logging: true
 		});
 
-		global.cmp("init", {
+		global.cmp('init', {
 			scriptSrc: fakeScriptSrc,
 			gdprApplies: true,
 			logging: true
 		});
 
 		expect(log.mock.calls).to.have.length(1);
-		expect(log.mock.calls[0][0]).to.contain("Only call init once");
+		expect(log.mock.calls[0][0]).to.contain('Only call init once');
 
 		log.mockRestore();
 		done();
 	});
 
-	describe("Complete CMP loading with reimport of loader shim", () => {
+	describe('Complete CMP loading with reimport of loader shim', () => {
 		let appendChild;
 
 		beforeEach(() => {
 			window.fetch = jest.fn().mockImplementation(src => {
-				if (src === "https://vendorlist.consensu.org/vendorlist.json") {
+				if (src === 'https://vendorlist.consensu.org/vendorlist.json') {
 					return Promise.resolve({
 						json: () => {
 							return vendorlist;
@@ -110,7 +110,7 @@ describe("cmpLoader as script tag", () => {
 				return Promise.resolve(src);
 			});
 			appendChild = window.document.body.appendChild = jest.fn(() => {
-				require("../s1/cmp"); // need to require this here because there is no built version that we can script load
+				require('../s1/cmp'); // need to require this here because there is no built version that we can script load
 			});
 		});
 
@@ -119,28 +119,28 @@ describe("cmpLoader as script tag", () => {
 			jest.resetModules();
 		});
 
-		it("triggers isLoaded after loading complete CMP", done => {
-			global.cmp("init", {
+		it('triggers isLoaded after loading complete CMP', done => {
+			global.cmp('init', {
 				scriptSrc: fakeScriptSrc,
 				gdprApplies: true
 			});
 
-			global.cmp("addEventListener", "isLoaded", result => {
-				expect(result.event).to.equal("isLoaded");
+			global.cmp('addEventListener', 'isLoaded', result => {
+				expect(result.event).to.equal('isLoaded');
 				done();
 			});
 		});
 
-		it("triggers callback on init after loading complete CMP", done => {
+		it('triggers callback on init after loading complete CMP', done => {
 			global.cmp(
-				"init",
+				'init',
 				{
 					scriptSrc: fakeScriptSrc,
 					gdprApplies: true
 				},
 				() => {
 					const init = global.cmp.commandQueue.find(({ command }) => {
-						return command === "init";
+						return command === 'init';
 					});
 					expect(init).to.be.undefined;
 					done();
@@ -148,7 +148,7 @@ describe("cmpLoader as script tag", () => {
 			);
 		});
 
-		it("triggers callback on init and isLoaded after loading complete CMP", done => {
+		it('triggers callback on init and isLoaded after loading complete CMP', done => {
 			let count = 0;
 			const callback = () => {
 				count++;
@@ -158,7 +158,7 @@ describe("cmpLoader as script tag", () => {
 			};
 
 			global.cmp(
-				"init",
+				'init',
 				{
 					scriptSrc: fakeScriptSrc,
 					gdprApplies: true
@@ -166,12 +166,12 @@ describe("cmpLoader as script tag", () => {
 				callback
 			);
 
-			global.cmp("addEventListener", "isLoaded", callback);
+			global.cmp('addEventListener', 'isLoaded', callback);
 		});
 
-		it("auto accepts consents", done => {
+		it('auto accepts consents', done => {
 			global.cmp(
-				"init",
+				'init',
 				{
 					scriptSrc: fakeScriptSrc,
 					gdprApplies: true,
@@ -180,27 +180,24 @@ describe("cmpLoader as script tag", () => {
 				result => {
 					expect(result.consentRequired).to.be.true;
 					expect(result.errorMsg).to.be.empty;
-					expect(document.cookie.indexOf("gdpr_opt_in=1")).to.be.above(1);
+					expect(document.cookie.indexOf('gdpr_opt_in=1')).to.be.above(1);
 					done();
 				}
 			);
 		});
 
-		it("auto accepts consents and shows banner", done => {
-			expect(document.cookie.indexOf("euconsent")).to.be.below(0);
+		it('auto accepts consents and shows banner', done => {
+			expect(document.cookie.indexOf('euconsent')).to.be.below(0);
 
 			let toggleConsentToolShowing;
 
-			global.cmp("addEventListener", "isLoaded", () => {
+			global.cmp('addEventListener', 'isLoaded', () => {
 				const store = global.cmp.store;
-				toggleConsentToolShowing = jest.spyOn(
-					store,
-					"toggleConsentToolShowing"
-				);
+				toggleConsentToolShowing = jest.spyOn(store, 'toggleConsentToolShowing');
 			});
 
 			global.cmp(
-				"init",
+				'init',
 				{
 					scriptSrc: fakeScriptSrc,
 					gdprApplies: true,
@@ -209,7 +206,7 @@ describe("cmpLoader as script tag", () => {
 				result => {
 					expect(result.consentRequired).to.be.true;
 					expect(result.errorMsg).to.be.empty;
-					expect(document.cookie.indexOf("gdpr_opt_in=1")).to.be.above(1);
+					expect(document.cookie.indexOf('gdpr_opt_in=1')).to.be.above(1);
 					expect(toggleConsentToolShowing.mock.calls).to.have.length(1);
 					toggleConsentToolShowing.mockRestore();
 					done();
@@ -217,16 +214,16 @@ describe("cmpLoader as script tag", () => {
 			);
 		});
 
-		it("triggers onConsentChanged with autoconsent", done => {
-			expect(document.cookie.indexOf("euconsent")).to.equal(-1);
+		it('triggers onConsentChanged with autoconsent', done => {
+			expect(document.cookie.indexOf('euconsent')).to.equal(-1);
 
-			global.cmp("addEventListener", "onConsentChanged", () => {
-				expect(document.cookie.indexOf("gdpr_opt_in=1")).to.be.above(1);
+			global.cmp('addEventListener', 'onConsentChanged', () => {
+				expect(document.cookie.indexOf('gdpr_opt_in=1')).to.be.above(1);
 				done();
 			});
 
 			global.cmp(
-				"init",
+				'init',
 				{
 					scriptSrc: fakeScriptSrc,
 					gdprApplies: true,
@@ -239,19 +236,19 @@ describe("cmpLoader as script tag", () => {
 			);
 		});
 
-		it("auto upgrades consent and does not trigger onConsentChanged when consent found with correctable error", done => {
-			expect(document.cookie.indexOf("euconsent")).to.equal(-1);
-			expect(document.cookie.indexOf("gdpr_opt_in")).to.equal(-1);
-			setCookie("euconsent", oldEuconsentCookie);
-			setCookie("gdpr_opt_in", "1");
-			expect(document.cookie.indexOf("euconsent")).to.be.above(-1);
-			expect(document.cookie.indexOf("gdpr_opt_in")).to.be.above(-1);
+		it('auto upgrades consent and does not trigger onConsentChanged when consent found with correctable error', done => {
+			expect(document.cookie.indexOf('euconsent')).to.equal(-1);
+			expect(document.cookie.indexOf('gdpr_opt_in')).to.equal(-1);
+			setCookie('euconsent', oldEuconsentCookie);
+			setCookie('gdpr_opt_in', '1');
+			expect(document.cookie.indexOf('euconsent')).to.be.above(-1);
+			expect(document.cookie.indexOf('gdpr_opt_in')).to.be.above(-1);
 
 			const onConsentChanged = jest.fn();
-			global.cmp("addEventListener", "onConsentChanged", onConsentChanged);
+			global.cmp('addEventListener', 'onConsentChanged', onConsentChanged);
 
 			global.cmp(
-				"init",
+				'init',
 				{
 					scriptSrc: fakeScriptSrc,
 					gdprApplies: true
@@ -260,9 +257,9 @@ describe("cmpLoader as script tag", () => {
 					expect(result.consentRequired).to.be.true;
 					expect(result.errorMsg).to.be.empty;
 					expect(result.warningMsg).to.equal(
-						"Consent found for version 165, but received vendor list version 5. Consent upgraded, show consent notice"
+						'Consent found for version 165, but received vendor list version 5. Consent upgraded, show consent notice'
 					);
-					expect(document.cookie.indexOf("gdpr_opt_in=1")).to.be.above(1);
+					expect(document.cookie.indexOf('gdpr_opt_in=1')).to.be.above(1);
 
 					setTimeout(() => {
 						// notification happens after init callback, so wait a tick
@@ -274,19 +271,19 @@ describe("cmpLoader as script tag", () => {
 			);
 		});
 
-		it("auto upgrades consent and triggers onConsentChanged when gdpr_opt_in_cookie is reset", done => {
-			expect(document.cookie.indexOf("euconsent")).to.equal(-1);
-			expect(document.cookie.indexOf("gdpr_opt_in")).to.equal(-1);
-			setCookie("euconsent", oldEuconsentCookie);
-			expect(document.cookie.indexOf("euconsent")).to.be.above(-1);
+		it('auto upgrades consent and triggers onConsentChanged when gdpr_opt_in_cookie is reset', done => {
+			expect(document.cookie.indexOf('euconsent')).to.equal(-1);
+			expect(document.cookie.indexOf('gdpr_opt_in')).to.equal(-1);
+			setCookie('euconsent', oldEuconsentCookie);
+			expect(document.cookie.indexOf('euconsent')).to.be.above(-1);
 
-			global.cmp("addEventListener", "onConsentChanged", () => {
-				expect(document.cookie.indexOf("gdpr_opt_in=1")).to.be.above(-1);
+			global.cmp('addEventListener', 'onConsentChanged', () => {
+				expect(document.cookie.indexOf('gdpr_opt_in=1')).to.be.above(-1);
 				done();
 			});
 
 			global.cmp(
-				"init",
+				'init',
 				{
 					scriptSrc: fakeScriptSrc,
 					gdprApplies: true
@@ -295,23 +292,23 @@ describe("cmpLoader as script tag", () => {
 					expect(result.consentRequired).to.be.true;
 					expect(result.errorMsg).to.be.empty;
 					expect(result.warningMsg).to.equal(
-						"Consent found for version 165, but received vendor list version 5. Consent upgraded, show consent notice"
+						'Consent found for version 165, but received vendor list version 5. Consent upgraded, show consent notice'
 					);
-					expect(document.cookie.indexOf("gdpr_opt_in=1")).to.be.above(1);
+					expect(document.cookie.indexOf('gdpr_opt_in=1')).to.be.above(1);
 				}
 			);
 		});
 
-		it("does not trigger onConsentChanged when errorMsg present and consent exists", done => {
-			expect(document.cookie.indexOf("euconsent")).to.equal(-1);
-			setCookie("euconsent", oldEuconsentCookie);
-			expect(document.cookie.indexOf("euconsent")).to.equal(0);
+		it('does not trigger onConsentChanged when errorMsg present and consent exists', done => {
+			expect(document.cookie.indexOf('euconsent')).to.equal(-1);
+			setCookie('euconsent', oldEuconsentCookie);
+			expect(document.cookie.indexOf('euconsent')).to.equal(0);
 
 			const onConsentChanged = jest.fn();
-			global.cmp("addEventListener", "onConsentChanged", onConsentChanged);
+			global.cmp('addEventListener', 'onConsentChanged', onConsentChanged);
 
 			global.cmp(
-				"init",
+				'init',
 				{
 					scriptSrc: fakeScriptSrc,
 					gdprApplies: true,
@@ -320,10 +317,10 @@ describe("cmpLoader as script tag", () => {
 				result => {
 					expect(result.consentRequired).to.be.true;
 					expect(result.errorMsg).to.equal(
-						"Consent found for version 165, but received vendor list version 5. Show consent tool"
+						'Consent found for version 165, but received vendor list version 5. Show consent tool'
 					);
 					expect(result.warningMsg).to.be.empty;
-					expect(document.cookie.indexOf("gdpr_opt_in=1")).to.be.above(1);
+					expect(document.cookie.indexOf('gdpr_opt_in=1')).to.be.above(1);
 
 					setTimeout(() => {
 						// notification happens after init callback, so wait a tick
@@ -335,23 +332,21 @@ describe("cmpLoader as script tag", () => {
 			);
 		});
 
-		it("does not autoconsent or trigger onConsentChanged when autoconsent is off", done => {
-			expect(document.cookie.indexOf("euconsent")).to.equal(-1);
+		it('does not autoconsent or trigger onConsentChanged when autoconsent is off', done => {
+			expect(document.cookie.indexOf('euconsent')).to.equal(-1);
 
 			const onConsentChanged = jest.fn();
-			global.cmp("addEventListener", "onConsentChanged", onConsentChanged);
+			global.cmp('addEventListener', 'onConsentChanged', onConsentChanged);
 
 			global.cmp(
-				"init",
+				'init',
 				{
 					scriptSrc: fakeScriptSrc,
 					gdprApplies: true
 				},
 				result => {
 					expect(result.consentRequired).to.be.true;
-					expect(result.errorMsg).to.equal(
-						"No consent data found. Show consent tool"
-					);
+					expect(result.errorMsg).to.equal('No consent data found. Show consent tool');
 					expect(result.hasConsented).to.be.false;
 
 					setTimeout(() => {
@@ -364,12 +359,12 @@ describe("cmpLoader as script tag", () => {
 			);
 		});
 
-		it("triggers onConsentChanged when flipping gdpr_opt_in bit", done => {
-			setCookie("gdpr_opt_in", "0"); // tests that we convert gdpr_opt_in cookie to boolean correctly
+		it('triggers onConsentChanged when flipping gdpr_opt_in bit', done => {
+			setCookie('gdpr_opt_in', '0'); // tests that we convert gdpr_opt_in cookie to boolean correctly
 			const onConsentChanged = jest.fn();
-			global.cmp("addEventListener", "onConsentChanged", onConsentChanged);
+			global.cmp('addEventListener', 'onConsentChanged', onConsentChanged);
 			global.cmp(
-				"init",
+				'init',
 				{
 					scriptSrc: fakeScriptSrc,
 					gdprApplies: true,

--- a/src/test/loader.inline.test.js
+++ b/src/test/loader.inline.test.js
@@ -1,106 +1,106 @@
 /* eslint-disable max-nested-callbacks */
 /* eslint-disable no-eval */
 
-import {expect} from 'chai';
-import fs from 'fs';
-import vendorlist from '../docs/assets/vendorlist.json';
-import {COOKIE_DOMAIN} from '../lib/cookie/cookie';
-import {deleteAllCookies, setCookie, oldEuconsentCookie} from './helpers';
+import { expect } from "chai";
+import fs from "fs";
+import vendorlist from "../docs/assets/vendorlist.json";
+import { COOKIE_DOMAIN } from "../lib/cookie/cookie";
+import { deleteAllCookies, setCookie, oldEuconsentCookie } from "./helpers";
 
-const fakeScriptSrc = './fake-loader-src.js';
+const fakeScriptSrc = "./fake-loader-src.js";
 
-describe('cmpLoader as script tag', () => {
+describe("cmpLoader as script tag", () => {
 	let appendChild;
 
 	beforeEach(() => {
 		appendChild = window.document.body.appendChild = jest.fn(() => {});
-		const content = fs.readFileSync('./src/loader.js');
-		eval(content + '; global.cmp = cmp');
+		const content = fs.readFileSync("./src/loader.js");
+		eval(content + "; global.cmp = cmp");
 	});
 
 	afterEach(() => {
 		deleteAllCookies(COOKIE_DOMAIN);
-		eval('; global.cmp = null; cmp = null;');
+		eval("; global.cmp = null; cmp = null;");
 		jest.restoreAllMocks();
 		appendChild.mockRestore();
 	});
 
-	it('loads cmp as script tag', done => {
+	it("loads cmp as script tag", done => {
 		expect(global.cmp).to.not.be.undefined;
-		expect(typeof global.cmp).to.equal('function');
+		expect(typeof global.cmp).to.equal("function");
 		done();
 	});
 
-	it('warns when no scriptSrc provided', done => {
-		const log = jest.spyOn(window.console, 'log');
+	it("warns when no scriptSrc provided", done => {
+		const log = jest.spyOn(window.console, "log");
 
-		global.cmp('init', {
+		global.cmp("init", {
 			logging: true
 		});
 		expect(log.mock.calls).to.have.length(1);
-		expect(log.mock.calls[0][0]).to.contain('Provide src');
+		expect(log.mock.calls[0][0]).to.contain("Provide src");
 		log.mockRestore();
 		done();
 	});
 
-	it('warns when gdprApplies is false', done => {
-		const log = jest.spyOn(window.console, 'log');
-		global.cmp('init', {
+	it("warns when gdprApplies is false", done => {
+		const log = jest.spyOn(window.console, "log");
+		global.cmp("init", {
 			scriptSrc: fakeScriptSrc,
 			gdprApplies: false,
 			logging: true
 		});
 
 		expect(log.mock.calls).to.have.length(1);
-		expect(log.mock.calls[0][0]).to.contain('gdprApplies turned off so no CMP');
+		expect(log.mock.calls[0][0]).to.contain("gdprApplies turned off so no CMP");
 
 		log.mockRestore();
 		done();
 	});
 
-	it('appends scriptSrc if gdprApplies and scriptSrc provided', done => {
-		const createElement = jest.spyOn(window.document, 'createElement');
+	it("appends scriptSrc if gdprApplies and scriptSrc provided", done => {
+		const createElement = jest.spyOn(window.document, "createElement");
 
-		global.cmp('init', {
+		global.cmp("init", {
 			scriptSrc: fakeScriptSrc,
 			gdprApplies: true
 		});
 
 		expect(createElement.mock.calls).to.have.length(1);
-		expect(createElement.mock.calls[0][0]).to.contain('script');
+		expect(createElement.mock.calls[0][0]).to.contain("script");
 		expect(appendChild.mock.calls).to.have.length(1);
 
 		createElement.mockRestore();
 		done();
 	});
 
-	it('warns on multiple init calls', done => {
-		const log = jest.spyOn(window.console, 'log');
-		global.cmp('init', {
+	it("warns on multiple init calls", done => {
+		const log = jest.spyOn(window.console, "log");
+		global.cmp("init", {
 			scriptSrc: fakeScriptSrc,
 			gdprApplies: true,
 			logging: true
 		});
 
-		global.cmp('init', {
+		global.cmp("init", {
 			scriptSrc: fakeScriptSrc,
 			gdprApplies: true,
 			logging: true
 		});
 
 		expect(log.mock.calls).to.have.length(1);
-		expect(log.mock.calls[0][0]).to.contain('Only call init once');
+		expect(log.mock.calls[0][0]).to.contain("Only call init once");
 
 		log.mockRestore();
 		done();
 	});
 
-	describe('Complete CMP loading with reimport of loader shim', () => {
+	describe("Complete CMP loading with reimport of loader shim", () => {
 		let appendChild;
 
 		beforeEach(() => {
 			window.fetch = jest.fn().mockImplementation(src => {
-				if (src === 'https://vendorlist.consensu.org/vendorlist.json') {
+				if (src === "https://vendorlist.consensu.org/vendorlist.json") {
 					return Promise.resolve({
 						json: () => {
 							return vendorlist;
@@ -110,7 +110,7 @@ describe('cmpLoader as script tag', () => {
 				return Promise.resolve(src);
 			});
 			appendChild = window.document.body.appendChild = jest.fn(() => {
-				require('../s1/cmp'); // need to require this here because there is no built version that we can script load
+				require("../s1/cmp"); // need to require this here because there is no built version that we can script load
 			});
 		});
 
@@ -119,28 +119,28 @@ describe('cmpLoader as script tag', () => {
 			jest.resetModules();
 		});
 
-		it('triggers isLoaded after loading complete CMP', done => {
-			global.cmp('init', {
+		it("triggers isLoaded after loading complete CMP", done => {
+			global.cmp("init", {
 				scriptSrc: fakeScriptSrc,
 				gdprApplies: true
 			});
 
-			global.cmp('addEventListener', 'isLoaded', result => {
-				expect(result.event).to.equal('isLoaded');
+			global.cmp("addEventListener", "isLoaded", result => {
+				expect(result.event).to.equal("isLoaded");
 				done();
 			});
 		});
 
-		it('triggers callback on init after loading complete CMP', done => {
+		it("triggers callback on init after loading complete CMP", done => {
 			global.cmp(
-				'init',
+				"init",
 				{
 					scriptSrc: fakeScriptSrc,
 					gdprApplies: true
 				},
 				() => {
-					const init = global.cmp.commandQueue.find(({command}) => {
-						return command === 'init';
+					const init = global.cmp.commandQueue.find(({ command }) => {
+						return command === "init";
 					});
 					expect(init).to.be.undefined;
 					done();
@@ -148,7 +148,7 @@ describe('cmpLoader as script tag', () => {
 			);
 		});
 
-		it('triggers callback on init and isLoaded after loading complete CMP', done => {
+		it("triggers callback on init and isLoaded after loading complete CMP", done => {
 			let count = 0;
 			const callback = () => {
 				count++;
@@ -158,7 +158,7 @@ describe('cmpLoader as script tag', () => {
 			};
 
 			global.cmp(
-				'init',
+				"init",
 				{
 					scriptSrc: fakeScriptSrc,
 					gdprApplies: true
@@ -166,12 +166,12 @@ describe('cmpLoader as script tag', () => {
 				callback
 			);
 
-			global.cmp('addEventListener', 'isLoaded', callback);
+			global.cmp("addEventListener", "isLoaded", callback);
 		});
 
-		it('auto accepts consents', done => {
+		it("auto accepts consents", done => {
 			global.cmp(
-				'init',
+				"init",
 				{
 					scriptSrc: fakeScriptSrc,
 					gdprApplies: true,
@@ -180,24 +180,24 @@ describe('cmpLoader as script tag', () => {
 				result => {
 					expect(result.consentRequired).to.be.true;
 					expect(result.errorMsg).to.be.empty;
-					expect(document.cookie.indexOf('gdpr_opt_in=1')).to.be.above(1);
+					expect(document.cookie.indexOf("gdpr_opt_in=1")).to.be.above(1);
 					done();
 				}
 			);
 		});
 
-		it('auto accepts consents and shows footer', done => {
-			expect(document.cookie.indexOf('euconsent')).to.be.below(0);
+		it("auto accepts consents and shows footer", done => {
+			expect(document.cookie.indexOf("euconsent")).to.be.below(0);
 
 			let toggleFooterShowing;
 
-			global.cmp('addEventListener', 'isLoaded', () => {
+			global.cmp("addEventListener", "isLoaded", () => {
 				const store = global.cmp.store;
-				toggleFooterShowing = jest.spyOn(store, 'toggleFooterShowing');
+				toggleFooterShowing = jest.spyOn(store, "toggleFooterShowing");
 			});
 
 			global.cmp(
-				'init',
+				"init",
 				{
 					scriptSrc: fakeScriptSrc,
 					gdprApplies: true,
@@ -206,7 +206,7 @@ describe('cmpLoader as script tag', () => {
 				result => {
 					expect(result.consentRequired).to.be.true;
 					expect(result.errorMsg).to.be.empty;
-					expect(document.cookie.indexOf('gdpr_opt_in=1')).to.be.above(1);
+					expect(document.cookie.indexOf("gdpr_opt_in=1")).to.be.above(1);
 					expect(toggleFooterShowing.mock.calls).to.have.length(1);
 					toggleFooterShowing.mockRestore();
 					done();
@@ -214,16 +214,16 @@ describe('cmpLoader as script tag', () => {
 			);
 		});
 
-		it('triggers onConsentChanged with autoconsent', done => {
-			expect(document.cookie.indexOf('euconsent')).to.equal(-1);
+		it("triggers onConsentChanged with autoconsent", done => {
+			expect(document.cookie.indexOf("euconsent")).to.equal(-1);
 
-			global.cmp('addEventListener', 'onConsentChanged', () => {
-				expect(document.cookie.indexOf('gdpr_opt_in=1')).to.be.above(1);
+			global.cmp("addEventListener", "onConsentChanged", () => {
+				expect(document.cookie.indexOf("gdpr_opt_in=1")).to.be.above(1);
 				done();
 			});
 
 			global.cmp(
-				'init',
+				"init",
 				{
 					scriptSrc: fakeScriptSrc,
 					gdprApplies: true,
@@ -236,19 +236,19 @@ describe('cmpLoader as script tag', () => {
 			);
 		});
 
-		it('auto upgrades consent and does not trigger onConsentChanged when consent found with correctable error', done => {
-			expect(document.cookie.indexOf('euconsent')).to.equal(-1);
-			expect(document.cookie.indexOf('gdpr_opt_in')).to.equal(-1);
-			setCookie('euconsent', oldEuconsentCookie);
-			setCookie('gdpr_opt_in', '1');
-			expect(document.cookie.indexOf('euconsent')).to.be.above(-1);
-			expect(document.cookie.indexOf('gdpr_opt_in')).to.be.above(-1);
+		it("auto upgrades consent and does not trigger onConsentChanged when consent found with correctable error", done => {
+			expect(document.cookie.indexOf("euconsent")).to.equal(-1);
+			expect(document.cookie.indexOf("gdpr_opt_in")).to.equal(-1);
+			setCookie("euconsent", oldEuconsentCookie);
+			setCookie("gdpr_opt_in", "1");
+			expect(document.cookie.indexOf("euconsent")).to.be.above(-1);
+			expect(document.cookie.indexOf("gdpr_opt_in")).to.be.above(-1);
 
 			const onConsentChanged = jest.fn();
-			global.cmp('addEventListener', 'onConsentChanged', onConsentChanged);
+			global.cmp("addEventListener", "onConsentChanged", onConsentChanged);
 
 			global.cmp(
-				'init',
+				"init",
 				{
 					scriptSrc: fakeScriptSrc,
 					gdprApplies: true
@@ -258,9 +258,9 @@ describe('cmpLoader as script tag', () => {
 					expect(result.consentRequired).to.be.true;
 					expect(result.errorMsg).to.be.empty;
 					expect(result.warningMsg).to.equal(
-						'Consent found for version 165, but received vendor list version 5. Consent upgraded, show consent notice'
+						"Consent found for version 165, but received vendor list version 5. Consent upgraded, show consent notice"
 					);
-					expect(document.cookie.indexOf('gdpr_opt_in=1')).to.be.above(1);
+					expect(document.cookie.indexOf("gdpr_opt_in=1")).to.be.above(1);
 
 					setTimeout(() => {
 						// notification happens after init callback, so wait a tick
@@ -272,19 +272,19 @@ describe('cmpLoader as script tag', () => {
 			);
 		});
 
-		it('auto upgrades consent and triggers onConsentChanged when gdpr_opt_in_cookie is reset', done => {
-			expect(document.cookie.indexOf('euconsent')).to.equal(-1);
-			expect(document.cookie.indexOf('gdpr_opt_in')).to.equal(-1);
-			setCookie('euconsent', oldEuconsentCookie);
-			expect(document.cookie.indexOf('euconsent')).to.be.above(-1);
+		it("auto upgrades consent and triggers onConsentChanged when gdpr_opt_in_cookie is reset", done => {
+			expect(document.cookie.indexOf("euconsent")).to.equal(-1);
+			expect(document.cookie.indexOf("gdpr_opt_in")).to.equal(-1);
+			setCookie("euconsent", oldEuconsentCookie);
+			expect(document.cookie.indexOf("euconsent")).to.be.above(-1);
 
-			global.cmp('addEventListener', 'onConsentChanged', () => {
-				expect(document.cookie.indexOf('gdpr_opt_in=1')).to.be.above(-1);
+			global.cmp("addEventListener", "onConsentChanged", () => {
+				expect(document.cookie.indexOf("gdpr_opt_in=1")).to.be.above(-1);
 				done();
 			});
 
 			global.cmp(
-				'init',
+				"init",
 				{
 					scriptSrc: fakeScriptSrc,
 					gdprApplies: true
@@ -294,23 +294,23 @@ describe('cmpLoader as script tag', () => {
 					expect(result.consentRequired).to.be.true;
 					expect(result.errorMsg).to.be.empty;
 					expect(result.warningMsg).to.equal(
-						'Consent found for version 165, but received vendor list version 5. Consent upgraded, show consent notice'
+						"Consent found for version 165, but received vendor list version 5. Consent upgraded, show consent notice"
 					);
-					expect(document.cookie.indexOf('gdpr_opt_in=1')).to.be.above(1);
+					expect(document.cookie.indexOf("gdpr_opt_in=1")).to.be.above(1);
 				}
 			);
 		});
 
-		it('does not trigger onConsentChanged when errorMsg present and consent exists', done => {
-			expect(document.cookie.indexOf('euconsent')).to.equal(-1);
-			setCookie('euconsent', oldEuconsentCookie);
-			expect(document.cookie.indexOf('euconsent')).to.equal(0);
+		it("does not trigger onConsentChanged when errorMsg present and consent exists", done => {
+			expect(document.cookie.indexOf("euconsent")).to.equal(-1);
+			setCookie("euconsent", oldEuconsentCookie);
+			expect(document.cookie.indexOf("euconsent")).to.equal(0);
 
 			const onConsentChanged = jest.fn();
-			global.cmp('addEventListener', 'onConsentChanged', onConsentChanged);
+			global.cmp("addEventListener", "onConsentChanged", onConsentChanged);
 
 			global.cmp(
-				'init',
+				"init",
 				{
 					scriptSrc: fakeScriptSrc,
 					gdprApplies: true,
@@ -319,10 +319,10 @@ describe('cmpLoader as script tag', () => {
 				result => {
 					expect(result.consentRequired).to.be.true;
 					expect(result.errorMsg).to.equal(
-						'Consent found for version 165, but received vendor list version 5. Show consent tool'
+						"Consent found for version 165, but received vendor list version 5. Show consent tool"
 					);
 					expect(result.warningMsg).to.be.empty;
-					expect(document.cookie.indexOf('gdpr_opt_in=1')).to.be.above(1);
+					expect(document.cookie.indexOf("gdpr_opt_in=1")).to.be.above(1);
 
 					setTimeout(() => {
 						// notification happens after init callback, so wait a tick
@@ -334,14 +334,14 @@ describe('cmpLoader as script tag', () => {
 			);
 		});
 
-		it('does not autoconsent or trigger onConsentChanged when autoconsent is off', done => {
-			expect(document.cookie.indexOf('euconsent')).to.equal(-1);
+		it("does not autoconsent or trigger onConsentChanged when autoconsent is off", done => {
+			expect(document.cookie.indexOf("euconsent")).to.equal(-1);
 
 			const onConsentChanged = jest.fn();
-			global.cmp('addEventListener', 'onConsentChanged', onConsentChanged);
+			global.cmp("addEventListener", "onConsentChanged", onConsentChanged);
 
 			global.cmp(
-				'init',
+				"init",
 				{
 					scriptSrc: fakeScriptSrc,
 					gdprApplies: true
@@ -349,7 +349,7 @@ describe('cmpLoader as script tag', () => {
 				result => {
 					expect(result.consentRequired).to.be.true;
 					expect(result.errorMsg).to.equal(
-						'No consent data found. Show consent tool'
+						"No consent data found. Show consent tool"
 					);
 					expect(result.hasConsented).to.be.false;
 


### PR DESCRIPTION
## background

Found an issue when reviewing the Search integration of CMP 

Ticket: https://openmail.atlassian.net/projects/NS/issues/NS-1691

- [x] trigger onConsentChanged last in `init` flow for easier listener management (to more easily avoid double calls) 
- [x] fix issue in gdpr_opt_in cookie check 
- [x] automatically update code styling and check in prettier configs.

## test plan

Auto
```
yarn test
```
Manual
```
yarn dev
# http://localhost:8080/reference.html 
# 1. onConsentChanged not triggered on first init with autoConsent selected
# 2. update preferences and see onConsentChanged is triggered. 
# 3. reload, change consent (content to all), see onConsentChanged triggered 
# 4. continue opening and closing CMP and consenting / disallowing to see that `onConsentChanged` is triggered as expected
```