### PR TITLE
feat (cookie) remove domain inference and expose config option to set cookie Domain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+<a name="1.3.3"></a>
+
+## [1.3.3](https://github.com/openmail/system1-cmp/compare/v1.3.2...v1.3.3) (2019-12-02)
+
+### Feature
+
+- [x] Add `cookieDomain` config option to allow subdomain cookies
+
+### Fix
+
+- [x] Remove inference of domain in cookie setting because `co.uk` style public-suffixes make this difficult to implement
+
 <a name="1.3.2"></a>
 
 ## [1.3.2](https://github.com/openmail/system1-cmp/compare/v1.3.1...v1.3.2) (2019-11-22)

--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ const config = {
   pubVendorListLocation: '//s.flocdn.com/cmp/pubvendors.json', // OPTIONAL, whitelists vendors
   logging: false,
   customPurposeListLocation: './purposes.json',
+  cookieDomain: '.example.com',
   globalVendorListLocation: '//vendorlist.consensu.org/vendorlist.json',
   globalConsentLocation: './portal.html',
   storeConsentGlobally: false,
@@ -140,6 +141,7 @@ cmp('init', config);
 - `shouldAutoUpgradeConsent`: OPTIONAL: true by default, if user previously consented and vendor list changed, automatically upgrade consent and display a notice
 - `theme`: OPTIONAL object to provide style overrides,
   - `isBannerModal`: OPTIONAL: boolean, false by deafult, true to use Modal on initial CMP banner
+- `cookieDomain`: String: OPTIONAL: domain cookie is written to (used for subdomaining a cookie), (ex: `.example.com` writes a cookie readable by \*.example.com)
 
 #### init: callback
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "system1-cmp",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "System1 Consent Management Platform for GDPR Compliance",
   "scripts": {
     "clean": "rimraf ./dist",

--- a/src/docs/assets/portal.js
+++ b/src/docs/assets/portal.js
@@ -2,15 +2,12 @@ import Promise from 'promise-polyfill';
 import 'whatwg-fetch';
 import log from '../../lib/log';
 
-const host = (window && window.location && window.location.hostname) || '';
-const parts = host.split('.');
-const COOKIE_DOMAIN = parts.length > 1 ? `;domain=.${parts.slice(-2).join('.')}` : '';
 const COOKIE_MAX_AGE = 33696000;
 const COOKIE_NAME = 'euconsent';
 
 const readVendorListPromise = fetch('./vendorlist.json', {
 	headers: {
-		'Accept': 'application/json',
+		Accept: 'application/json',
 		'Content-Type': 'application/json'
 	}
 })
@@ -23,13 +20,18 @@ function readCookie(name) {
 	const value = '; ' + document.cookie;
 	const parts = value.split('; ' + name + '=');
 	if (parts.length === 2) {
-		return Promise.resolve(parts.pop().split(';').shift());
+		return Promise.resolve(
+			parts
+				.pop()
+				.split(';')
+				.shift()
+		);
 	}
 	return Promise.resolve();
 }
 
-function writeCookie({ name, value, path = '/'}) {
-	document.cookie = `${name}=${value}${COOKIE_DOMAIN};path=${path};max-age=${COOKIE_MAX_AGE}`;
+function writeCookie({ name, value, path = '/' }) {
+	document.cookie = `${name}=${value};path=${path};max-age=${COOKIE_MAX_AGE}`;
 	return Promise.resolve();
 }
 
@@ -40,22 +42,25 @@ const commands = {
 		return readCookie(COOKIE_NAME);
 	},
 
-	writeVendorConsent: ({encodedValue}) => {
-		return writeCookie({name: COOKIE_NAME, value: encodedValue});
+	writeVendorConsent: ({ encodedValue }) => {
+		return writeCookie({ name: COOKIE_NAME, value: encodedValue });
 	}
 };
 
-window.addEventListener('message', (event) => {
+window.addEventListener('message', event => {
 	const data = event.data.vendorConsent;
 	if (data && typeof commands[data.command] === 'function') {
 		const { command } = data;
 		commands[command](data).then(result => {
-			event.source.postMessage({
-				vendorConsent: {
-					...data,
-					result
-				}
-			}, event.origin);
+			event.source.postMessage(
+				{
+					vendorConsent: {
+						...data,
+						result
+					}
+				},
+				event.origin
+			);
 		});
 	}
 });

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -3,6 +3,7 @@ import log from './log';
 // These options are documented at https://acdn.adnxs.com/cmp/docs/#/config
 // We highly recommend reading the options as the defaults may not fit your goals.
 const defaultConfig = {
+	cookieDomain: null,
 	customPurposeListLocation: './purposes.json',
 	// The location of the latest vendorlist to use.
 	globalVendorListLocation: 'https://vendorlist.consensu.org/vendorlist.json',
@@ -24,27 +25,28 @@ class Config {
 		this.update(defaultConfig);
 	}
 
-	update = (updates) => {
+	update = updates => {
 		if (updates && typeof updates === 'object') {
 			const validKeys = Object.keys(defaultConfig);
-			const { validUpdates, invalidKeys } = Object.keys(updates).reduce((acc, key) => {
-				if (validKeys.indexOf(key) > -1) {
-					acc.validUpdates = {
-						...acc.validUpdates,
-						[key]: updates[key]
-					};
-				}
-				else {
-					acc.invalidKeys.push(key);
-				}
-				return acc;
-			}, { validUpdates: {}, invalidKeys: [] });
+			const { validUpdates, invalidKeys } = Object.keys(updates).reduce(
+				(acc, key) => {
+					if (validKeys.indexOf(key) > -1) {
+						acc.validUpdates = {
+							...acc.validUpdates,
+							[key]: updates[key]
+						};
+					} else {
+						acc.invalidKeys.push(key);
+					}
+					return acc;
+				},
+				{ validUpdates: {}, invalidKeys: [] }
+			);
 
 			Object.assign(this, validUpdates);
 			if (invalidKeys.length) {
 				log.warn(`Invalid CMP config values not applied: ${invalidKeys.join(', ')}`);
 			}
-
 		}
 	};
 }

--- a/src/lib/cookie/cookie.test.js
+++ b/src/lib/cookie/cookie.test.js
@@ -281,7 +281,7 @@ describe('cookie', () => {
 	it('returns correct subdomain cookieDomain', () => {
 		global.window = Object.create(window);
 		const location = window.location;
-		const hostname = 'test.dummy.com';
+		const hostname = 'test.dummy.co.uk';
 		Object.defineProperty(window, 'location', {
 			value: {
 				hostname
@@ -289,9 +289,9 @@ describe('cookie', () => {
 		});
 		expect(window.location.hostname).to.equal(hostname);
 		config.update({
-			cookieDomain: '.dummy.com'
+			cookieDomain: '.dummy.co.uk'
 		});
-		expect(getCookieDomain()).to.equal(';domain=.dummy.com');
+		expect(getCookieDomain()).to.equal(';domain=.dummy.co.uk');
 
 		// reset
 		Object.defineProperty(window, 'location', location);

--- a/src/lib/cookie/cookie.test.js
+++ b/src/lib/cookie/cookie.test.js
@@ -4,6 +4,7 @@ import customPurposeList from '../../docs/assets/purposes.json';
 import config from '../config';
 
 import {
+	getCookieDomain,
 	writeCookie,
 	encodeVendorConsentData,
 	decodeVendorConsentData,
@@ -22,56 +23,55 @@ jest.mock('../portal');
 const mockPortal = require('../portal');
 
 const vendorList = {
-	'version': 1,
-	'origin': 'http://ib.adnxs.com/vendors.json',
-	'purposes': [
+	version: 1,
+	origin: 'http://ib.adnxs.com/vendors.json',
+	purposes: [
 		{
-			'id': 1,
-			'name': 'Accessing a Device or Browser'
+			id: 1,
+			name: 'Accessing a Device or Browser'
 		},
 		{
-			'id': 2,
-			'name': 'Advertising Personalisation'
+			id: 2,
+			name: 'Advertising Personalisation'
 		},
 		{
-			'id': 3,
-			'name': 'Analytics'
+			id: 3,
+			name: 'Analytics'
 		},
 		{
-			'id': 4,
-			'name': 'Content Personalisation'
+			id: 4,
+			name: 'Content Personalisation'
 		}
 	],
-	'vendors': [
+	vendors: [
 		{
-			'id': 1,
-			'name': 'Globex'
+			id: 1,
+			name: 'Globex'
 		},
 		{
-			'id': 2,
-			'name': 'Initech'
+			id: 2,
+			name: 'Initech'
 		},
 		{
-			'id': 3,
-			'name': 'CRS'
+			id: 3,
+			name: 'CRS'
 		},
 		{
-			'id': 4,
-			'name': 'Umbrella'
+			id: 4,
+			name: 'Umbrella'
 		},
 		{
-			'id': 10,
-			'name': 'Pierce and Pierce'
+			id: 10,
+			name: 'Pierce and Pierce'
 		},
 		{
-			'id': 8,
-			'name': 'Aperture'
+			id: 8,
+			name: 'Aperture'
 		}
 	]
 };
 
 describe('cookie', () => {
-
 	const aDate = new Date('2018-07-15 PDT');
 
 	beforeEach(() => {
@@ -101,7 +101,7 @@ describe('cookie', () => {
 			selectedVendorIds: new Set([1, 2, 4])
 		};
 
-		const encodedString = encodeVendorConsentData({...vendorConsentData, vendorList});
+		const encodedString = encodeVendorConsentData({ ...vendorConsentData, vendorList });
 		const decoded = decodeVendorConsentData(encodedString);
 
 		expect(decoded).to.deep.equal(vendorConsentData);
@@ -113,7 +113,7 @@ describe('cookie', () => {
 			cmpId: 1,
 			vendorListVersion: 1,
 			created: aDate,
-			lastUpdated: aDate,
+			lastUpdated: aDate
 		};
 
 		const publisherConsentData = {
@@ -127,13 +127,14 @@ describe('cookie', () => {
 		};
 
 		const encodedString = encodePublisherConsentData({
-			...vendorConsentData, ...publisherConsentData,
+			...vendorConsentData,
+			...publisherConsentData,
 			vendorList,
 			customPurposeList
 		});
 		const decoded = decodePublisherConsentData(encodedString);
 
-		expect(decoded).to.deep.equal({...vendorConsentData, ...publisherConsentData});
+		expect(decoded).to.deep.equal({ ...vendorConsentData, ...publisherConsentData });
 	});
 
 	it('writes and reads the local cookie when globalConsent = false', () => {
@@ -146,7 +147,7 @@ describe('cookie', () => {
 			cmpId: 1,
 			vendorListVersion: 1,
 			created: aDate,
-			lastUpdated: aDate,
+			lastUpdated: aDate
 		};
 
 		return writeVendorConsentCookie(vendorConsentData).then(() => {
@@ -167,7 +168,7 @@ describe('cookie', () => {
 			cmpId: 1,
 			vendorListVersion: 1,
 			created: aDate,
-			lastUpdated: aDate,
+			lastUpdated: aDate
 		};
 
 		return writeVendorConsentCookie(vendorConsentData).then(() => {
@@ -186,7 +187,7 @@ describe('cookie', () => {
 			cmpId: 1,
 			vendorListVersion: 1,
 			created: aDate,
-			lastUpdated: aDate,
+			lastUpdated: aDate
 		};
 
 		return readVendorConsentCookie(vendorConsentData).then(() => {
@@ -206,7 +207,7 @@ describe('cookie', () => {
 			vendorListVersion: 1,
 			publisherPurposeVersion: 1,
 			created: aDate,
-			lastUpdated: aDate,
+			lastUpdated: aDate
 		};
 
 		writePublisherConsentCookie(publisherConsentData);
@@ -214,19 +215,24 @@ describe('cookie', () => {
 
 		expect(document.cookie).to.contain(PUBLISHER_CONSENT_COOKIE_NAME);
 		expect(fromCookie).to.deep.include(publisherConsentData);
+
+		config.update({
+			cookieDomain: ''
+		});
 	});
 
 	it('converts selected vendor list to a range', () => {
 		const maxVendorId = Math.max(...vendorList.vendors.map(vendor => vendor.id));
 		const ranges = convertVendorsToRanges(maxVendorId, new Set([2, 3, 4]));
 
-		expect(ranges).to.deep.equal([{
-			isRange: true,
-			startVendorId: 2,
-			endVendorId: 4
-		}]);
+		expect(ranges).to.deep.equal([
+			{
+				isRange: true,
+				startVendorId: 2,
+				endVendorId: 4
+			}
+		]);
 	});
-
 
 	it('converts selected vendor list to multiple ranges', () => {
 		const maxVendorId = Math.max(...vendorList.vendors.map(vendor => vendor.id));
@@ -249,5 +255,45 @@ describe('cookie', () => {
 				endVendorId: undefined
 			}
 		]);
+	});
+
+	it('returns current cookieDomain', () => {
+		config.update({
+			cookieDomain: ''
+		});
+		expect(getCookieDomain()).to.equal('');
+	});
+
+	it('returns configured cookieDomain', () => {
+		config.update({
+			cookieDomain: 'localhost'
+		});
+		expect(getCookieDomain()).to.equal('');
+	});
+
+	it('defaults to correct cookieDomain', () => {
+		config.update({
+			cookieDomain: '.dummy.com'
+		});
+		expect(getCookieDomain()).to.equal('');
+	});
+
+	it('returns correct subdomain cookieDomain', () => {
+		global.window = Object.create(window);
+		const location = window.location;
+		const hostname = 'test.dummy.com';
+		Object.defineProperty(window, 'location', {
+			value: {
+				hostname
+			}
+		});
+		expect(window.location.hostname).to.equal(hostname);
+		config.update({
+			cookieDomain: '.dummy.com'
+		});
+		expect(getCookieDomain()).to.equal(';domain=.dummy.com');
+
+		// reset
+		Object.defineProperty(window, 'location', location);
 	});
 });

--- a/src/s1cmp.hbs
+++ b/src/s1cmp.hbs
@@ -33,6 +33,7 @@
 				isBannerModal: true
 			},
 			gdprApplies: true,
+			cookieDomain: '.zooquizzes.com',
 			// allowedVendorIds: null,
 			shouldAutoConsent: false,
 			shouldAutoConsentWithFooter: true

--- a/src/s1cmp.hbs
+++ b/src/s1cmp.hbs
@@ -33,7 +33,7 @@
 				isBannerModal: true
 			},
 			gdprApplies: true,
-			cookieDomain: '.zooquizzes.com',
+			cookieDomain: '.zoo.com',
 			// allowedVendorIds: null,
 			shouldAutoConsent: false,
 			shouldAutoConsentWithFooter: true

--- a/src/test/loader.inline.test.js
+++ b/src/test/loader.inline.test.js
@@ -4,7 +4,7 @@
 import { expect } from 'chai';
 import fs from 'fs';
 import vendorlist from '../docs/assets/vendorlist.json';
-import { COOKIE_DOMAIN } from '../lib/cookie/cookie';
+import { getCookieDomain } from '../lib/cookie/cookie';
 import { deleteAllCookies, setCookie, oldEuconsentCookie } from './helpers';
 
 const fakeScriptSrc = './fake-loader-src.js';
@@ -19,7 +19,7 @@ describe('cmpLoader as script tag', () => {
 	});
 
 	afterEach(() => {
-		deleteAllCookies(COOKIE_DOMAIN);
+		deleteAllCookies(getCookieDomain());
 		eval('; global.cmp = null; cmp = null;');
 		jest.restoreAllMocks();
 		appendChild.mockRestore();
@@ -380,6 +380,26 @@ describe('cmpLoader as script tag', () => {
 						onConsentChanged.mockRestore();
 						done();
 					}, 0);
+				}
+			);
+		});
+
+		it('defaults to correct cookie domain', done => {
+			global.cmp(
+				'init',
+				{
+					scriptSrc: fakeScriptSrc,
+					gdprApplies: true,
+					shouldAutoConsentWithFooter: true,
+					cookieDomain: 'localhost'
+				},
+				result => {
+					expect(result.consentRequired).to.be.true;
+					expect(result.hasConsented).to.be.true;
+					const cookieDomain = getCookieDomain();
+					expect(cookieDomain).to.equal('');
+					expect(document.cookie.indexOf('gdpr_opt_in=1')).to.be.above(1);
+					done();
 				}
 			);
 		});


### PR DESCRIPTION
## Background
Bug: Cookie not being set on `co.uk` sites 

- [x] remove inference of domain to set cookie to work across subdomains automatically 
- [x] add config option `cookieDomain` to allow subdomain cookie option 

## Test Plan

```
yarn test
```
