### PR TITLE
refactor (cookie: domain) allow wildcard cookie domain on naked primary domain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+<a name="1.3.4"></a>
+
+## [1.3.4](https://github.com/openmail/system1-cmp/compare/v1.3.3...v1.3.4) (2019-12-03)
+
+### Refactor
+
+- [x] `getCookieDomain()` allows wildcard cookie on naked primary domain (ex: setting `cookieDomain: '.zoo.com'` while on `https://zoo.com`)
+
 <a name="1.3.3"></a>
 
 ## [1.3.3](https://github.com/openmail/system1-cmp/compare/v1.3.2...v1.3.3) (2019-12-02)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "system1-cmp",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "description": "System1 Consent Management Platform for GDPR Compliance",
   "scripts": {
     "clean": "rimraf ./dist",

--- a/src/lib/cookie/cookie.js
+++ b/src/lib/cookie/cookie.js
@@ -23,7 +23,7 @@ const getCookieDomain = () => {
 	const { cookieDomain: customCookieDomain } = config;
 	const hostname = (window && window.location && window.location.hostname) || '';
 	const cookieDomain =
-		hostname.split('.').length > 1 && customCookieDomain && hostname.indexOf(customCookieDomain) > -1
+		hostname.split('.').length > 1 && customCookieDomain && `.${hostname}`.indexOf(customCookieDomain) > -1
 			? `;domain=${customCookieDomain}`
 			: '';
 	return cookieDomain;

--- a/src/lib/cookie/cookie.test.js
+++ b/src/lib/cookie/cookie.test.js
@@ -257,21 +257,7 @@ describe('cookie', () => {
 		]);
 	});
 
-	it('returns current cookieDomain', () => {
-		config.update({
-			cookieDomain: ''
-		});
-		expect(getCookieDomain()).to.equal('');
-	});
-
-	it('returns configured cookieDomain', () => {
-		config.update({
-			cookieDomain: 'localhost'
-		});
-		expect(getCookieDomain()).to.equal('');
-	});
-
-	it('defaults to correct cookieDomain', () => {
+	it('returns null on invalid cookieDomain', () => {
 		config.update({
 			cookieDomain: '.dummy.com'
 		});
@@ -293,7 +279,7 @@ describe('cookie', () => {
 		global.window.location = resetLocation;
 	});
 
-	it('allows wildcard cookieDomain on naked domain', () => {
+	it('returns wildcard cookieDomain on naked domain', () => {
 		const hostname = 'zoo.com';
 		const resetLocation = global.window.location;
 		delete global.window.location;
@@ -303,12 +289,11 @@ describe('cookie', () => {
 			cookieDomain: '.zoo.com'
 		});
 		expect(getCookieDomain()).to.equal(';domain=.zoo.com');
-
-		// reset
 		global.window.location = resetLocation;
 	});
 
-	it('defaults to null when on primary TLD', () => {
+	// special case for localhost and new custom TLDs
+	it('returns null when on primary TLD', () => {
 		const hostname = 'localhost';
 		const resetLocation = global.window.location;
 		delete global.window.location;
@@ -318,8 +303,6 @@ describe('cookie', () => {
 			cookieDomain: 'localhost'
 		});
 		expect(getCookieDomain()).to.equal(''); // null
-
-		// reset
 		global.window.location = resetLocation;
 	});
 });

--- a/src/lib/cookie/cookie.test.js
+++ b/src/lib/cookie/cookie.test.js
@@ -279,14 +279,10 @@ describe('cookie', () => {
 	});
 
 	it('returns correct subdomain cookieDomain', () => {
-		global.window = Object.create(window);
-		const location = window.location;
 		const hostname = 'test.dummy.co.uk';
-		Object.defineProperty(window, 'location', {
-			value: {
-				hostname
-			}
-		});
+		const resetLocation = global.window.location;
+		delete global.window.location;
+		global.window.location = { hostname };
 		expect(window.location.hostname).to.equal(hostname);
 		config.update({
 			cookieDomain: '.dummy.co.uk'
@@ -294,6 +290,36 @@ describe('cookie', () => {
 		expect(getCookieDomain()).to.equal(';domain=.dummy.co.uk');
 
 		// reset
-		Object.defineProperty(window, 'location', location);
+		global.window.location = resetLocation;
+	});
+
+	it('allows wildcard cookieDomain on naked domain', () => {
+		const hostname = 'zoo.com';
+		const resetLocation = global.window.location;
+		delete global.window.location;
+		global.window.location = { hostname };
+		expect(window.location.hostname).to.equal(hostname);
+		config.update({
+			cookieDomain: '.zoo.com'
+		});
+		expect(getCookieDomain()).to.equal(';domain=.zoo.com');
+
+		// reset
+		global.window.location = resetLocation;
+	});
+
+	it('defaults to null when on primary TLD', () => {
+		const hostname = 'localhost';
+		const resetLocation = global.window.location;
+		delete global.window.location;
+		global.window.location = { hostname };
+		expect(window.location.hostname).to.equal(hostname);
+		config.update({
+			cookieDomain: 'localhost'
+		});
+		expect(getCookieDomain()).to.equal(''); // null
+
+		// reset
+		global.window.location = resetLocation;
 	});
 });

--- a/src/s1cmp.hbs
+++ b/src/s1cmp.hbs
@@ -33,7 +33,7 @@
 				isBannerModal: true
 			},
 			gdprApplies: true,
-			cookieDomain: '.zoo.com',
+			// cookieDomain: '.zoo.com',
 			// allowedVendorIds: null,
 			shouldAutoConsent: false,
 			shouldAutoConsentWithFooter: true


### PR DESCRIPTION
## background

Previously, when setting a wildcard `cookieDomain: '.example.com'` and visiting the site at the naked domain `https://example.com`, the cookieDomain would default to null. Ideally though, it should allow the wildcard in this case. 

- [x] allow wildcard domain on naked domains

## test plan

```
yarn test
```