### PR TITLE
fix(reference): Add postMessage call to init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
+<a name="1.3.6"></a>
+
+## [1.3.6](https://github.com/openmail/system1-cmp/compare/v1.3.4...v1.3.6) (2020-02-20)
+
+### Fix
+
+- [x] Add postMessage call to init
+
 <a name="1.3.5"></a>
 
-## [1.3.4](https://github.com/openmail/system1-cmp/compare/v1.3.4...v1.3.5) (2019-12-03)
+## [1.3.5](https://github.com/openmail/system1-cmp/compare/v1.3.4...v1.3.5) (2020-02-19)
 
 ### Docs
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "system1-cmp",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "description": "System1 Consent Management Platform for GDPR Compliance",
   "scripts": {
     "clean": "rimraf ./dist",

--- a/src/s1cmp.hbs
+++ b/src/s1cmp.hbs
@@ -43,7 +43,7 @@
 
 		function onConsentChanged(result) {
 			if (window.ReactNativeWebView && window.ReactNativeWebView.postMessage) {
-				window.ReactNativeWebView.postMessage(document.cookie);
+				window.ReactNativeWebView.postMessage('ON_CONSENT_CHANGED:' + document.cookie);
 			}
 			if (document.cookie.indexOf("gdpr_opt_in=1") < 0) {
 				console.log("cmp:onConsentChanged all-consent:failed", result);
@@ -55,7 +55,7 @@
 
 		cmp('init', config, function (result) {
 			if (window.ReactNativeWebView && window.ReactNativeWebView.postMessage) {
-				window.ReactNativeWebView.postMessage(document.cookie);
+				window.ReactNativeWebView.postMessage('INIT:' + document.cookie);
 			}
 			if (result.consentRequired) {
 				if (result.warningMsg) {
@@ -76,6 +76,12 @@
 				cmp('addEventListener', 'onConsentChanged', onConsentChanged);
 			} else {
 				console.log("cmp:init: consent not required", result);
+			}
+		});
+
+		cmp('addEventListener', 'onSubmit', () => {
+			if (window.ReactNativeWebView && window.ReactNativeWebView.postMessage) {
+				window.ReactNativeWebView.postMessage('ON_SUBMIT:' + document.cookie);
 			}
 		});
 

--- a/src/s1cmp.hbs
+++ b/src/s1cmp.hbs
@@ -54,6 +54,9 @@
 		}
 
 		cmp('init', config, function (result) {
+			if (window.ReactNativeWebView && window.ReactNativeWebView.postMessage) {
+				window.ReactNativeWebView.postMessage(document.cookie);
+			}
 			if (result.consentRequired) {
 				if (result.warningMsg) {
 					console.log('cmp:init: warningMsg', result.warningMsg);
@@ -62,6 +65,7 @@
 					console.log('cmp:init: errorMsg', result.errorMsg);
 					cmp('showConsentTool');
 				} else {
+
 					// consent achieved
 					if (document.cookie.indexOf("gdpr_opt_in=1") >= 0) {
 						console.log("cmp:init: all consent achieved", result);


### PR DESCRIPTION
We were only calling postMessage when consent _changed_. When consent was the same we weren't sending the cookie up correctly

