### PR TITLE
refactor (info-acs: listeners) post cookie to native app on init, consent, and submit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+<a name="1.4.1"></a>
+
+## [1.4.1](https://github.com/openmail/system1-cmp/compare/v1.4.0...v1.4.1) (2020-02-21)
+
+### Refactor
+
+- [x] Adds postMessage to Native Device from info-acs.html
+
 <a name="1.4.0"></a>
 
 ## [1.4.0](https://github.com/openmail/system1-cmp/compare/v1.3.5...v1.4.0) (2020-02-20)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "system1-cmp",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "System1 Consent Management Platform for TCF 1.1 GDPR Compliance",
   "scripts": {
     "clean": "rimraf ./dist",

--- a/src/s1/reference/info-acs.html
+++ b/src/s1/reference/info-acs.html
@@ -14,6 +14,12 @@
 			<%= props.loader %>
 		</script>
 		<script>
+			const MESSAGE_TYPE = {
+				INIT: 'INIT',
+				ON_SUBMIT: 'ON_SUBMIT',
+				ON_CONSENT_CHANGED: 'ON_CONSENT_CHANGED',
+			};
+
 			const config = {
 				scriptSrc: './cmp.js',
 				pubVendorListLocation: './config/info.pubvendors.json',
@@ -73,10 +79,16 @@
 				shouldAutoConsentWithFooter: false
 			}
 
-			function onConsentChanged(result) {
-				if (window.ReactNativeWebView && window.ReactNativeWebView.postMessage) {
-					window.ReactNativeWebView.postMessage(document.cookie);
+			function nativePostMessage(namespace, msg) {
+				if (window.ReactnativeWebView && window.ReactNativeWebView.postMessage) {
+					window.ReactNativeWebView.postMessage(namespace + ':' + msg);
+				} else {
+					console.log(namespace + ':' + msg);
 				}
+			}
+
+			function onConsentChanged(result) {
+				nativePostMessage(MESSAGE_TYPE.ON_CONSENT_CHANGED, document.cookie);
 				if (document.cookie.indexOf("gdpr_opt_in=1") < 0) {
 					console.log("cmp:onConsentChanged all-consent:failed", result);
 					// window.location.reload();
@@ -86,6 +98,7 @@
 			}
 
 			cmp('init', config, function (result) {
+				nativePostMessage(MESSAGE_TYPE.INIT, document.cookie);
 				if (result.consentRequired) {
 					if (result.warningMsg) {
 						console.log('cmp:init: warningMsg', result.warningMsg);
@@ -107,7 +120,10 @@
 				}
 			});
 
-			cmp('showConsentTool')
+			cmp('showConsentTool');
+			cmp('addEventListener', 'onSubmit', function () {
+				nativePostMessage(MESSAGE_TYPE.ON_SUBMIT, document.cookie);
+			});
 
 		</script>
 	</body>


### PR DESCRIPTION
## background

Use ReactNative webview postMessage hook to push cookie data into native app 

## test plan
```
yarn test
```