### PR TITLE
fix (logging) remove untyped param from CMPOnSubmit event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.5.1](https://github.com/openmail/system1-cmp/compare/v1.5.0...v1.5.1) (2020-04-29)
+
+### Fix
+
+- [x] Remove unknown prop from `CMPOnSubmit` event
+
 ## [1.5.0](https://github.com/openmail/system1-cmp/compare/v1.4.3...v1.5.0) (2020-04-29)
 
 ### Feat

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "system1-cmp",
-	"version": "1.5.0",
+	"version": "1.5.1",
 	"description": "System1 Consent Management Platform for TCF 1.1 GDPR Compliance",
 	"scripts": {
 		"clean": "rimraf ./dist",

--- a/src/s1/cmp.js
+++ b/src/s1/cmp.js
@@ -222,7 +222,6 @@ const handleConsentResult = ({
 			track('CMPOnSubmit', {
 				hasConsented,
 				hasConsentChanged: hasConsented !== hasConsentedCookie,
-				vendorConsentData,
 			});
 		}
 


### PR DESCRIPTION
## background
 - [x] fixes error when logging `CMPOnSubmit` due to unknown property

## test plan
```
yarn dev
# browse to http://localhost:8080/reference.html#s1&debug=true 
# click "ok" and see event log without error
```