### PR TITLE
 refactor (cmp: config) hoist flag shouldExpandPurposes to disable purposes-accordian-expanded by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.5.2](https://github.com/openmail/system1-cmp/compare/v1.5.0...v1.5.1) (2020-05-12)
+
+### Refactor
+
+- [x] Hoist auto-expand purposes accordian to config object
+
 ## [1.5.1](https://github.com/openmail/system1-cmp/compare/v1.5.0...v1.5.1) (2020-04-29)
 
 ### Fix

--- a/README.md
+++ b/README.md
@@ -126,6 +126,12 @@ const config = {
 	shouldAutoUpgradeConsent: true,
   theme: { //
     isBannerModal: true // OPTIONAL, to enable Banner as a modal or footer component
+    shouldExpandPurposes: true, // true by default, expands purposes on initial Baner
+    primaryColor: '#09f',
+    textLinkColor: '#09f',
+    boxShadow: 'none',
+    secondaryColor: '#869cc0',
+    featuresColor: '#d0d3d7'
   }
 
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "system1-cmp",
-	"version": "1.5.1",
+	"version": "1.5.2",
 	"description": "System1 Consent Management Platform for TCF 1.1 GDPR Compliance",
 	"scripts": {
 		"clean": "rimraf ./dist",

--- a/src/components/banner/banner.jsx
+++ b/src/components/banner/banner.jsx
@@ -6,13 +6,13 @@ import { SECTION_VENDOR_LIST } from '../popup/details/details';
 
 class LocalLabel extends Label {
 	static defaultProps = {
-		prefix: 'banner'
+		prefix: 'banner',
 	};
 }
 
 class PurposesLabel extends Label {
 	static defaultProps = {
-		prefix: 'purposes'
+		prefix: 'purposes',
 	};
 }
 
@@ -22,9 +22,12 @@ const PANEL_PURPOSE = 1;
 export default class Banner extends Component {
 	constructor(props) {
 		super(props);
+		const {
+			theme: { shouldExpandPurposes = true },
+		} = props;
 		this.state = {
-			isExpanded: true,
-			selectedPanelIndex: 1
+			isExpanded: shouldExpandPurposes,
+			selectedPanelIndex: 1,
 		};
 	}
 
@@ -38,7 +41,7 @@ export default class Banner extends Component {
 		document.removeEventListener('click', this.handleWindowClick);
 	};
 
-	onKeyDown = evt => {
+	onKeyDown = (evt) => {
 		evt = evt || window.event;
 		const { key = '', keyCode = '' } = evt;
 		const isEscape = key === 'Escape' || key === 'Esc' || keyCode === 27;
@@ -70,15 +73,15 @@ export default class Banner extends Component {
 		toggleFooterShowing(false);
 	};
 
-	handleInfo = index => () => {
+	handleInfo = (index) => () => {
 		const { isExpanded, selectedPanelIndex } = this.state;
 		this.setState({
 			selectedPanelIndex: index,
-			isExpanded: index !== selectedPanelIndex || !isExpanded
+			isExpanded: index !== selectedPanelIndex || !isExpanded,
 		});
 	};
 
-	handleWindowClick = e => {
+	handleWindowClick = (e) => {
 		if (this.bannerRef === e.target) {
 			this.onAcceptAll();
 		}
@@ -88,7 +91,7 @@ export default class Banner extends Component {
 		this.handleShowConsent();
 	};
 
-	handlePurposeItemClick = purposeItem => {
+	handlePurposeItemClick = (purposeItem) => {
 		return () => {
 			this.props.onSelectPurpose(purposeItem);
 		};
@@ -111,7 +114,7 @@ export default class Banner extends Component {
 			backgroundColor,
 			textColor,
 			textLightColor,
-			textLinkColor
+			textLinkColor,
 		} = theme;
 
 		const {} = theme;
@@ -128,16 +131,16 @@ export default class Banner extends Component {
 
 		return (
 			<div
-				ref={el => (this.bannerRef = el)}
+				ref={(el) => (this.bannerRef = el)}
 				class={bannerClasses.join(' ')}
 				style={{
 					boxShadow: boxShadow || `0px 0px 5px ${primaryColor}`,
 					backgroundColor,
-					color: textLightColor
+					color: textLightColor,
 				}}
 			>
 				<div class={style.content}>
-					<div class={style.message} ref={el => (this.messageRef = el)}>
+					<div class={style.message} ref={(el) => (this.messageRef = el)}>
 						<div class={style.info}>
 							<div class={style.title} style={{ color: textColor }}>
 								<LocalLabel localizeKey="title">Ads help us run this site</LocalLabel>
@@ -163,7 +166,7 @@ export default class Banner extends Component {
 									style={{
 										backgroundColor: primaryColor,
 										borderColor: primaryColor,
-										color: primaryTextColor
+										color: primaryTextColor,
 									}}
 								>
 									<LocalLabel localizeKey="links.accept">Continue to site</LocalLabel>
@@ -173,7 +176,7 @@ export default class Banner extends Component {
 								<div
 									class={[
 										style.option,
-										selectedPanelIndex === PANEL_COLLECTED && isExpanded ? style.expanded : ''
+										selectedPanelIndex === PANEL_COLLECTED && isExpanded ? style.expanded : '',
 									].join(' ')}
 								>
 									<a onClick={this.handleInfo(PANEL_COLLECTED)} class={style.detailExpand}>

--- a/src/s1/reference/s1cmp.html
+++ b/src/s1/reference/s1cmp.html
@@ -29,7 +29,8 @@
 			// localization: {},
 			// forceLocale: 'es',
 			theme: {
-				isBannerModal: false
+				isBannerModal: false,
+				shouldExpandPurposes: false
 			},
 			gdprApplies: true,
 			// cookieDomain: '.zoo.com',


### PR DESCRIPTION
## background
ticket: https://openmail.atlassian.net/browse/PFE-3064 
- [x] hoist flag `shouldExpandPurposes` to disable purposes-accordian-expanded by default 
- [x] update docs

## test plan
```
yarn dev
```
1. you can change the `shouldExpandPurposes` config setting in `s1/reference/s1cmp.html` to see results

<img width="346" alt="Screen Shot 2020-05-12 at 9 51 28 AM" src="https://user-images.githubusercontent.com/468002/81722408-31a0fb80-9436-11ea-8683-a2fdebf0d145.png">
