### PR TITLE
styles (banner) fix title spacing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.5.4](https://github.com/openmail/system1-cmp/compare/v1.5.3...v1.5.4) (2020-06-04)
+
+### Styles
+
+- [x] Spruce up title spacing
+
 ## [1.5.3](https://github.com/openmail/system1-cmp/compare/v1.5.2...v1.5.3) (2020-05-12)
 
 ### Refactor

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "system1-cmp",
-	"version": "1.5.3",
+	"version": "1.5.4",
 	"description": "System1 Consent Management Platform for TCF 1.1 GDPR Compliance",
 	"scripts": {
 		"clean": "rimraf ./dist",

--- a/src/components/banner/banner.less
+++ b/src/components/banner/banner.less
@@ -90,10 +90,11 @@
 					color: @color-text;
 					padding: 15px 0;
 					margin-bottom: 10px;
-					line-height: 28px;
-					
+					line-height: 32px;
+
 					@media @smartphone {
 						font-size: 28px;
+						line-height: 28px;
 						font-weight: bold;
 					}
 				}

--- a/src/components/banner/banner.less
+++ b/src/components/banner/banner.less
@@ -90,10 +90,10 @@
 					color: @color-text;
 					padding: 15px 0;
 					margin-bottom: 10px;
-
+					line-height: 28px;
+					
 					@media @smartphone {
 						font-size: 28px;
-						line-height: inherit;
 						font-weight: bold;
 					}
 				}

--- a/src/lib/translations.js
+++ b/src/lib/translations.js
@@ -271,9 +271,9 @@ export default {
 	},
 	fr: {
 		banner: {
-			title: 'Les cookies nous aident à vous délivrer un service de qualité.',
+			title: 'Utilisation des données',
 			description:
-				'Nos partenaires et nous-même utilisons les cookies afin de proposer du contenu et de la publicité pertinents.',
+				'Nos partenaires et nous utilisons des cookies afin d’adresser des contenus personnalisés et/ou publicités ciblées pour améliorer votre expérience.',
 			links: {
 				data: {
 					title: 'Données utilisées',


### PR DESCRIPTION
## background

When reading french version of CMP, noticed the header spacing is too tight, so this fixes header spacing

## test plan

Fixes Spacing In Case There is a very long header (example below)
<img width="321" alt="Screen Shot 2020-06-04 at 4 14 33 PM" src="https://user-images.githubusercontent.com/468002/83819473-cb974500-a67e-11ea-908c-942acf25cee1.png">

Fixes FR translation to be shorter
<img width="323" alt="Screen Shot 2020-06-05 at 9 16 36 AM" src="https://user-images.githubusercontent.com/468002/83899516-70606380-a70d-11ea-8a37-03f7fd61eec3.png">

