### PR TITLE
fix (loader: polyfills) add polyfill check for promise.finally / add data for localization error logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [2.0.3](https://github.com/openmail/system1-cmp/compare/v2.0.2...v2.0.3) (2020-09-15)
+
+### Fix
+
+- [x] tcf-2.0-loader add check for Promise finally.
+- [x] Add more information on localize fetch error log.
+
 ## [2.0.2](https://github.com/openmail/system1-cmp/compare/v2.0.1...v2.0.2) (2020-09-02)
 
 ### Feat

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 TCF 2.0 Consent Management Platform (CMP) UI tool. We are in the process of validating this CMP, we will update this repo once it passes TCF 2.0 validation.
 
-[Reference Page and Demo](https://s.flocdn.com/cmp/2.0.0/tcf-2.0.html)
+[Reference Page and Demo](https://s.flocdn.com/cmp/2.0.3/tcf-2.0.html)
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
@@ -33,7 +33,7 @@ TCF 2.0 Consent Management Platform (CMP) UI tool. We are in the process of vali
 API signatures have changed from the CMP TCF 1.1, but we've tried to keep the configuration process very similar. See a [working example in codepen](https://codepen.io/potench/pen/GRZZprw).
 
 ```html
-<script src="https://s.flocdn.com/cmp/2.0.0/tcf-2.0-loader.js"></script>
+<script src="https://s.flocdn.com/cmp/2.0.3/tcf-2.0-loader.js"></script>
 <script>
 	__tcfapi('onConsentAllChanged', 2, function (store) {
 		const hasConsented = document.cookie.indexOf('gdpr_opt_in=1') >= 0;
@@ -54,8 +54,8 @@ API signatures have changed from the CMP TCF 1.1, but we've tried to keep the co
 			gdprApplies: true,
 			debugging: true, // console logs
 			logging: true, // pixel logs for monitoring
-			baseUrl: 'https://s.flocdn.com/cmp/2.0.0/config/2.0', // base url for vendor-lists and translations
-			scriptSrc: 'https://s.flocdn.com/cmp/2.0.0/tcf-2.0-cmp.js', // cmp SDK
+			baseUrl: 'https://s.flocdn.com/cmp/2.0.3/config/2.0', // base url for vendor-lists and translations
+			scriptSrc: 'https://s.flocdn.com/cmp/2.0.3/tcf-2.0-cmp.js', // cmp SDK
 			publisherCountryCode: 'AA',
 			narrowedVendors: [], // ex [1,2,3,4],
 			theme: {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "system1-cmp",
-	"version": "2.0.2",
+	"version": "2.0.3",
 	"description": "System1 Consent Management Platform for TCF 1.1 GDPR Compliance",
 	"scripts": {
 		"clean": "rimraf ./dist",

--- a/src/s1/constants.js
+++ b/src/s1/constants.js
@@ -61,37 +61,3 @@ export const LANGUAGES = [
 ];
 
 export const DEFAULT_LANGUAGE = LANGUAGES[0];
-
-export const LANGUAGES_2 = {
-	en: 'English',
-	bg: 'Bulgarian',
-	ca: 'Catalan',
-	cs: 'Czech',
-	da: 'Danish',
-	de: 'German',
-	el: 'Greek',
-	es: 'Spanish',
-	et: 'Estonian',
-	fi: 'Finnish',
-	fr: 'French',
-	hr: 'Croatian',
-	hu: 'Hungarian',
-	it: 'Italian',
-	ja: 'Japanese',
-	lt: 'Lithuanian',
-	lv: 'Latvian',
-	mt: 'Maltese',
-	nl: 'Dutch',
-	no: 'Norwegian',
-	pl: 'Polish',
-	pt: 'Portuguese',
-	ro: 'Romanian',
-	// 'sr-cyrillic': 'Serbian Cryllic',
-	// 'sr-latin': 'Serbian Latin',
-	ru: 'Russian',
-	sk: 'Slovak',
-	sl: 'Slovenian',
-	sv: 'Swedish',
-	tr: 'Turkish',
-	zh: 'Chinese',
-};

--- a/src/s1/lib/localize.js
+++ b/src/s1/lib/localize.js
@@ -44,7 +44,7 @@ export const localize = (language) => {
 		.then((json) => flatten(json))
 		.catch((e) => {
 			logger(LOG_EVENTS.CMPError, {
-				message: `localizeError: ${e}`,
+				message: `localizeError: ${e} ${filename}`,
 			});
 		});
 };

--- a/src/s1/reference/tcf-2.0.html
+++ b/src/s1/reference/tcf-2.0.html
@@ -171,7 +171,7 @@
 				canLog: true,
 				canDebug: true,
 				// baseUrl: './config/2.0',
-				baseUrl: 'https://s.flocdn.com/cmp/2.0.0/config/2.0', // base url
+				baseUrl: 'https://s.flocdn.com/cmp/2.0.3/config/2.0', // base url
 				// versionedFilename: 'vendor-list.json', // vendor list json
 				scriptSrc: './tcf-2.0-cmp.js', // cmp SDK
 				// polyfillSrc: './polyfills.js',

--- a/src/s1/tcf-2.0-loader.js
+++ b/src/s1/tcf-2.0-loader.js
@@ -16,7 +16,7 @@
 			polyfillSrc = 'polyfillSrc',
 			shouldPolyfill = !window.Promise || !window.fetch || !window.Symbol;
 
-		// more intricate polyfill
+		// Test for specific functionality for some polyfills
 		if (!shouldPolyfill) {
 			var promiseTest = new Promise(function () {});
 			shouldPolyfill = !promiseTest.finally;

--- a/src/s1/tcf-2.0-loader.js
+++ b/src/s1/tcf-2.0-loader.js
@@ -16,6 +16,12 @@
 			polyfillSrc = 'polyfillSrc',
 			shouldPolyfill = !window.Promise || !window.fetch || !window.Symbol;
 
+		// more intricate polyfill
+		if (!shouldPolyfill) {
+			var promiseTest = new Promise(function () {});
+			shouldPolyfill = !promiseTest.finally;
+		}
+
 		function loadScript(src, done) {
 			var js = document.createElement('script');
 			js.src = src;


### PR DESCRIPTION
## background

- [x] add check for Promise.finally in loader.js / affects older IE Edge < = 17 
- [x] add more data to localization error. Seeing a lot of Access-Control errors and other related errors. 

## test plan

1. Verify site does not load polyfills in Chrome. [x]
1. Verify site does load polyfills based on "finally" check in Edge 17. [x]

## followup plan

1. review error logs for `localizeError` to investigate source of occasional "Access-Control-All" and "Unexpected token <" errors. 