### PR TITLE
refactor (dpl) upgrade dpl to test latest schema validation changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [2.1.2](https://github.com/openmail/system1-cmp/compare/2.1.1...2.1.2) (2020-10-20)
+
+### Refactor
+
+- [x] Upgrade DPL
+
 ## [2.1.1](https://github.com/openmail/system1-cmp/compare/2.1.0...2.1.1) (2020-09-30)
 
 ### Fix

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "system1-cmp",
-	"version": "2.1.1",
+	"version": "2.1.2",
 	"cmpVersion": 5,
 	"description": "System1 Consent Management Platform for TCF 1.1 GDPR Compliance",
 	"scripts": {
@@ -111,7 +111,7 @@
 	"dependencies": {
 		"@iabtcf/cmpapi": "1.1.3",
 		"@iabtcf/core": "1.1.3",
-		"@s1/dpl": "3.0.18",
+		"@s1/dpl": "3.2.1",
 		"classnames": "^2.2.5",
 		"codemirror": "^5.34.0",
 		"core-js": "^2.5.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1079,10 +1079,10 @@
     "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^13.0.0"
 
-"@s1/dpl@3.0.18":
-  version "3.0.18"
-  resolved "https://system1.jfrog.io/system1/api/npm/npm-virtual/@s1/dpl/-/@s1/dpl-3.0.18.tgz#a635d5e4015cda569c8699794b33133c1adfec2b"
-  integrity sha1-pjXV5AFc2lachpl5SzMTPBrf7Cs=
+"@s1/dpl@3.2.1":
+  version "3.2.1"
+  resolved "https://system1.jfrog.io/system1/api/npm/npm-virtual/@s1/dpl/-/@s1/dpl-3.2.1.tgz#00c61b9c69f912d394e4957f6d4ab8bcacb86e98"
+  integrity sha1-AMYbnGn5EtOU5JV/bUq4vKy4bpg=
   dependencies:
     "@babel/runtime" "^7.10.5"
     doctoc "^1.4.0"


### PR DESCRIPTION
## background

#### Refactor

- [x] Upgrade DPL for better event schema validation for optional DPL-enabled integrations

## test plan

1. `yarn dev`
2. Turn on DPL and validate debug output at http://localhost:8080/tcf-2.0.html?stacks=true#s1&debug=true 
3. Expect: no dpl schema errors 
